### PR TITLE
Convert fido-net-lib from .NET Core 2.1 to .NET Standard 2.0

### DIFF
--- a/fido2-net-lib/AuthDataHelper.cs
+++ b/fido2-net-lib/AuthDataHelper.cs
@@ -246,7 +246,7 @@ namespace Fido2NetLib
 
         public static bool IsValidPackedAttnCertSubject(string attnCertSubj)
         {
-            var dictSubject = attnCertSubj.Split(", ").Select(part => part.Split('=')).ToDictionary(split => split[0], split => split[1]);
+            var dictSubject = attnCertSubj.Split(new string[] { ", " }, StringSplitOptions.None).Select(part => part.Split('=')).ToDictionary(split => split[0], split => split[1]);
             return (0 != dictSubject["C"].Length ||
                 0 != dictSubject["O"].Length ||
                 0 != dictSubject["OU"].Length ||
@@ -266,7 +266,7 @@ namespace Fido2NetLib
         {
             if ((0 == len) && ((offset + 2) <= ab.Length))
             {
-                len = BitConverter.ToUInt16(ab.Slice(offset, 2).ToArray().Reverse().ToArray());
+                len = BitConverter.ToUInt16(ab.Slice(offset, 2).ToArray().Reverse().ToArray(), 0);
                 offset += 2;
             }
             byte[] result = null;
@@ -294,7 +294,7 @@ namespace Fido2NetLib
                 var longLenByte = GetSizedByteArray(attExtBytes, ref offset, 1);
                 if (null == longLenByte) throw new Fido2VerificationException("attExtBytes signature has invalid long form length");
                 Buffer.BlockCopy(longLenByte, 0, uint16Buffer, 0, 1);
-                longLen = BitConverter.ToUInt16(uint16Buffer);
+                longLen = BitConverter.ToUInt16(uint16Buffer, 0);
                 longLen &= (1 << 7);
             }
             // attestationVersion          
@@ -303,7 +303,7 @@ namespace Fido2NetLib
             var lenVersion = GetSizedByteArray(attExtBytes, ref offset, 1);
             if (null == lenVersion) throw new Fido2VerificationException("attExtBytes version length invalid");
             Buffer.BlockCopy(lenVersion, 0, uint16Buffer, 0, 1);
-            var version = GetSizedByteArray(attExtBytes, ref offset, BitConverter.ToUInt16(uint16Buffer));
+            var version = GetSizedByteArray(attExtBytes, ref offset, BitConverter.ToUInt16(uint16Buffer, 0));
 
             // attestationSecurityLevel   
 

--- a/fido2-net-lib/AuthenticatorAssertionResponse.cs
+++ b/fido2-net-lib/AuthenticatorAssertionResponse.cs
@@ -130,7 +130,7 @@ namespace Fido2NetLib
             if (true != AuthDataHelper.VerifySigWithCoseKey(data, coseKey, Signature)) throw new Fido2VerificationException("Signature did not match");
 
             // 17.
-            var counter = BitConverter.ToUInt32(authData.SignCount.ToArray().Reverse().ToArray());
+            var counter = BitConverter.ToUInt32(authData.SignCount.ToArray().Reverse().ToArray(), 0);
             if (counter > 0 && counter <= storedSignatureCounter)
             {
                 throw new Fido2VerificationException("SignatureCounter was not greater than stored SignatureCounter");

--- a/fido2-net-lib/AuthenticatorAttestationResponse.cs
+++ b/fido2-net-lib/AuthenticatorAttestationResponse.cs
@@ -287,7 +287,7 @@ namespace Fido2NetLib
                         }
                         if (("timestampMs" == claim.Type) && ("http://www.w3.org/2001/XMLSchema#integer64" == claim.ValueType))
                         {
-                            DateTime dt = DateTime.UnixEpoch.AddMilliseconds(double.Parse(claim.Value));
+                            DateTime dt = DateTimeHelper.UnixEpoch.AddMilliseconds(double.Parse(claim.Value));
                             if ((DateTime.UtcNow < dt) || (DateTime.UtcNow.AddMinutes(-1) > dt)) throw new Fido2VerificationException("Android SafetyNet timestampMs must be between one minute ago and now");
                         }
                     }

--- a/fido2-net-lib/DateTimeExtensions.cs
+++ b/fido2-net-lib/DateTimeExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Fido2NetLib
+{
+   internal static class DateTimeHelper
+    {
+        private static readonly DateTime _unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        internal static DateTime UnixEpoch
+        {
+            get { return _unixEpoch; }
+        }
+    }
+}

--- a/fido2-net-lib/Fido2NetLib.csproj
+++ b/fido2-net-lib/Fido2NetLib.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="PeterO.Cbor" Version="3.2.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.4" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
   </ItemGroup>
 

--- a/fido2-net-lib/TPM.cs
+++ b/fido2-net-lib/TPM.cs
@@ -62,13 +62,13 @@ namespace Fido2NetLib
             UInt16 totalSize = 0;
             if (null != totalBytes)
             {
-                totalSize = BitConverter.ToUInt16(totalBytes.ToArray().Reverse().ToArray());
+                totalSize = BitConverter.ToUInt16(totalBytes.ToArray().Reverse().ToArray(), 0);
             }
             UInt16 size = 0;
             var bytes = AuthDataHelper.GetSizedByteArray(ab, ref offset, 2);
             if (null != bytes)
             {
-                size = BitConverter.ToUInt16(bytes.ToArray().Reverse().ToArray());
+                size = BitConverter.ToUInt16(bytes.ToArray().Reverse().ToArray(), 0);
             }
             // If size is four, then the Name is a handle. 
             if (4 == size) throw new Fido2VerificationException("Unexpected handle in TPM2B_NAME");
@@ -93,9 +93,9 @@ namespace Fido2NetLib
             Raw = certInfo;
             var offset = 0;
             Magic = AuthDataHelper.GetSizedByteArray(certInfo, ref offset, 4);
-            if (0xff544347 != BitConverter.ToUInt32(Magic.ToArray().Reverse().ToArray())) throw new Fido2VerificationException("Bad magic number " + Magic.ToString());
+            if (0xff544347 != BitConverter.ToUInt32(Magic.ToArray().Reverse().ToArray(), 0)) throw new Fido2VerificationException("Bad magic number " + Magic.ToString());
             Type = AuthDataHelper.GetSizedByteArray(certInfo, ref offset, 2);
-            if (0x8017 != BitConverter.ToUInt16(Type.ToArray().Reverse().ToArray())) throw new Fido2VerificationException("Bad structure tag " + Type.ToString());
+            if (0x8017 != BitConverter.ToUInt16(Type.ToArray().Reverse().ToArray(), 0)) throw new Fido2VerificationException("Bad structure tag " + Type.ToString());
             QualifiedSigner = AuthDataHelper.GetSizedByteArray(certInfo, ref offset);
             ExtraData = AuthDataHelper.GetSizedByteArray(certInfo, ref offset);
             Clock = AuthDataHelper.GetSizedByteArray(certInfo, ref offset, 8);
@@ -133,7 +133,7 @@ namespace Fido2NetLib
 
             // TPMI_ALG_PUBLIC
             Type = AuthDataHelper.GetSizedByteArray(pubArea, ref offset, 2);
-            TpmAlg tpmalg = (TpmAlg)Enum.Parse(typeof(TpmAlg), BitConverter.ToUInt16(Type.ToArray().Reverse().ToArray()).ToString());
+            TpmAlg tpmalg = (TpmAlg)Enum.Parse(typeof(TpmAlg), BitConverter.ToUInt16(Type.ToArray().Reverse().ToArray(), 0).ToString());
 
             // TPMI_ALG_HASH 
             Alg = AuthDataHelper.GetSizedByteArray(pubArea, ref offset, 2);
@@ -175,7 +175,7 @@ namespace Fido2NetLib
                 var tmp = AuthDataHelper.GetSizedByteArray(pubArea, ref offset, 4);
                 if (null != tmp)
                 {
-                    Exponent = BitConverter.ToUInt32(tmp.ToArray());
+                    Exponent = BitConverter.ToUInt32(tmp.ToArray(), 0);
                     if (0 == Exponent) Exponent = System.Convert.ToUInt32(Math.Pow(2, 16) + 1);
                 }
             }


### PR DESCRIPTION
Proposing changing the fido2-net-lib project type to .NET Standard. It requires little change in code and the lib would be referenceable in all .NET implementations (see also [.NET Standard documentation](https://docs.microsoft.com/en-us/dotnet/standard/net-standard)).