### PR TITLE
Authenticator type selection, web browser support detection, result classes JSON properties improvements

### DIFF
--- a/Fido2Demo/Controller.cs
+++ b/Fido2Demo/Controller.cs
@@ -41,7 +41,7 @@ namespace Fido2Demo
 
         [HttpPost]
         [Route("/makeCredentialOptions")]
-        public JsonResult MakeCredentialOptions([FromForm] string username, [FromForm] string attType)
+        public JsonResult MakeCredentialOptions([FromForm] string username, [FromForm] string attType, [FromForm] string authType)
         {
             try
             {
@@ -57,7 +57,16 @@ namespace Fido2Demo
                 List<PublicKeyCredentialDescriptor> existingKeys = DemoStorage.GetCredentialsByUser(user).Select(c => c.Descriptor).ToList();
 
                 // 3. Create options
-                var options = _lib.RequestNewCredential(user, existingKeys, AuthenticatorSelection.Default, AttestationConveyancePreference.Parse(attType));
+                var authenticatorSelection =
+                    string.IsNullOrEmpty(authType) ?
+                    AuthenticatorSelection.Default :
+                    new AuthenticatorSelection
+                    {
+                        AuthenticatorAttachment = AuthenticatorAttachment.Parse(authType),
+                        RequireResidentKey = false,
+                        UserVerification = UserVerificationRequirement.Preferred
+                    };
+                var options = _lib.RequestNewCredential(user, existingKeys, authenticatorSelection, AttestationConveyancePreference.Parse(attType));
 
                 // 4. Temporarily store options, session/in-memory cache/redis/db
                 HttpContext.Session.SetString("fido2.attestationOptions", options.ToJson());

--- a/Fido2Demo/wwwroot/js/webauthn.js
+++ b/Fido2Demo/wwwroot/js/webauthn.js
@@ -1,3 +1,32 @@
+function markPlatformAuthenticatorUnavailable() {
+    
+    $('#platform-authenticator').attr("disabled", true);
+    showWarningAlert("Platform (TPM) authenticators not available");
+}
+
+function detectFIDOSupport() {
+    if (window.PublicKeyCredential === undefined ||
+        typeof window.PublicKeyCredential !== "function") {
+        $('#register-button').attr("disabled", true);
+        $('#login-button').attr("disabled", true);
+        showErrorAlert("WebAuthn is not currently supported by this browser");
+        return;
+    }
+
+    if (window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable !== "function") {
+        markPlatformAuthenticatorUnavailable();
+    } else if (typeof PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable === "function") {
+        PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable().then(function(available) {
+            if (!available) {
+                markPlatformAuthenticatorUnavailable();
+            }
+        }).catch(function(e) {
+            markPlatformAuthenticatorUnavailable();
+        });
+    }
+}
+
+
 function hexEncode(buf) {
     return Array.from(buf)
         .map(function (x) {
@@ -148,10 +177,12 @@ function makeCredential() {
     setUser();
 
     var attestation_type = $('#select-attestation').find(':selected').val();
+    var authenticator_attachment = $('#select-authenticator').find(':selected').val();
 
     var data = new FormData();
     data.append('username', state.user.name);
     data.append('attType', attestation_type);
+    data.append('authType', authenticator_attachment);
 
     fetch('/makeCredentialOptions', {
         method: 'POST', // or 'PUT'
@@ -415,6 +446,15 @@ function setCurrentUser(userResponse) {
 function showErrorAlert(msg) {
     $("#alert-msg").text(msg);
     $("#user-alert").show();
+}
+
+function showWarningAlert(msg) {
+    $("#warning-msg").text(msg);
+    $("#user-warning").show();
+}
+
+function hideWarningAlert() {
+    $("#user-warning").fadeOut(200);
 }
 
 function showSuccessAlert(msg) {

--- a/Fido2Demo/wwwroot/login.html
+++ b/Fido2Demo/wwwroot/login.html
@@ -15,7 +15,7 @@
     <link href="/stylesheets/styles.css" rel="stylesheet" type="text/css" />
 </head>
 
-<body>
+<body onload="detectFIDOSupport()">
     <div class="container">
         <div class="login-wrapper">
             <form class="form-signin mb-">
@@ -55,6 +55,16 @@
                                 <option value="indirect">Indirect</option>
                                 <option value="direct">Direct</option>
                             </select>
+                            <div class="input-group-prepend">
+                                <label class="input-group-text" for="authenticatorType">
+                                    Authenticator Type
+                                </label>
+                            </div>
+                            <select class="custom-select" id="select-authenticator">
+                                <option selected value="">Not specified</option>
+                                <option value="cross-platform">Cross Platform (Token)</option>
+                                <option id="platform-authenticator" value="platform">Platform (TPM)</option>
+                            </select>
                         </div>
                     </div>
                 </div>
@@ -64,9 +74,17 @@
                     <strong>Holy guacamole!</strong> You should check in on some of those fields below.
                 </div>
             </div>
+            <div class="warning-wrapper" id="user-warning" style="display:none">
+                <div class="alert alert-warning alert-dismissible fade show" role="alert">
+                    <span id="warning-msg"></span>
+                    <button type="button" class="close" aria-label="Close" onclick="hideWarningAlert()">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+            </div>
             <div class="text-center buttons">
-                <button class="btn btn-lg btn-primary" type="button" onclick="makeCredential()">Register a User/Credential</button>
-                <button class="btn btn-lg btn-primary" type="button" onclick="getAssertion()">Login with Credential</button>
+                <button id="register-button" class="btn btn-lg btn-primary" type="button" onclick="makeCredential()">Register a User/Credential</button>
+                <button id="login-button" class="btn btn-lg btn-primary" type="button" onclick="getAssertion()">Login with Credential</button>
 
             </div>
         </div>

--- a/fido2-net-lib/AssertionOptions.cs
+++ b/fido2-net-lib/AssertionOptions.cs
@@ -13,27 +13,32 @@ namespace Fido2NetLib
         /// <summary>
         /// This member represents a challenge that the selected authenticator signs, along with other data, when producing an authentication assertion.See the §13.1 Cryptographic Challenges security consideration.
         /// </summary>
+        [JsonProperty("challenge")]
         [JsonConverter(typeof(Base64UrlConverter))]
         public byte[] Challenge { get; set; }
 
         /// <summary>
         /// This member represents a challenge that the selected authenticator signs, along with other data, when producing an authentication assertion.See the §13.1 Cryptographic Challenges security consideration
         /// </summary>
+        [JsonProperty("timeout")]
         public uint Timeout { get; set; }
 
         /// <summary>
         /// This OPTIONAL member specifies the relying party identifier claimed by the caller.If omitted, its value will be the CredentialsContainer object’s relevant settings object's origin's effective domain
         /// </summary>
+        [JsonProperty("rpId")]
         public string RpId { get; set; }
 
         /// <summary>
         /// This OPTIONAL member contains a list of PublicKeyCredentialDescriptor objects representing public key credentials acceptable to the caller, in descending order of the caller’s preference(the first item in the list is the most preferred credential, and so on down the list)
         /// </summary>
+        [JsonProperty("allowCredentials")]
         public IEnumerable<PublicKeyCredentialDescriptor> AllowCredentials { get; set; }
 
         /// <summary>
         /// This member describes the Relying Party's requirements regarding user verification for the get() operation. Eligible authenticators are filtered to only those capable of satisfying this requirement
         /// </summary>
+        [JsonProperty("userVerification")]
         public UserVerificationRequirement UserVerification { get; set; }
 
         internal static AssertionOptions Create(Fido2.Configuration config, byte[] challenge, IEnumerable<PublicKeyCredentialDescriptor> allowedCredentials, UserVerificationRequirement userVerification)

--- a/fido2-net-lib/AuthDataHelper.cs
+++ b/fido2-net-lib/AuthDataHelper.cs
@@ -562,7 +562,7 @@ namespace Fido2NetLib
             {
                 tmp = PeterO.Cbor.CBORObject.Read(ms);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 throw new Fido2VerificationException("Failed to read credential public key from attested credential data");
             }

--- a/fido2-net-lib/CredentialCreateOptions.cs
+++ b/fido2-net-lib/CredentialCreateOptions.cs
@@ -51,6 +51,7 @@ namespace Fido2NetLib
         [JsonProperty("attestation")]
         public AttestationConveyancePreference Attestation { get; set; } = AttestationConveyancePreference.None;
 
+        [JsonProperty("authenticatorSelection")]
         public AuthenticatorSelection AuthenticatorSelection { get; set; }
 
         /// <summary>

--- a/fido2-net-lib/MetadataService.cs
+++ b/fido2-net-lib/MetadataService.cs
@@ -82,7 +82,7 @@ namespace Fido2NetLib
         public string RogueListURL { get; set; }
         [JsonProperty("rogueListHash")]
         public string RogueListHash { get; set; }
-        [JsonProperty("MetadataStatement")]
+        [JsonProperty("metadataStatement")]
         [JsonConverter(typeof(Base64UrlConverter))]
         public MetadataStatement MetadataStatement { get; set; }
     }
@@ -164,7 +164,7 @@ namespace Fido2NetLib
     }
     public class VerificationMethodANDCombinations
     {
-        [JsonProperty("VerificationMethodANDCombinations")]
+        [JsonProperty("verificationMethodANDCombinations")]
         public VerificationMethodDescriptor[] VerificationMethodAndCombinations { get; set; }
     }
     public class rgbPaletteEntry
@@ -284,8 +284,8 @@ namespace Fido2NetLib
         public EcdaaTrustAnchor[] EcdaaTrustAnchors { get; set; }
         [JsonProperty("icon")]
         public string Icon { get; set; }
-        [JsonProperty("supportedExtensions[]")]
-        public ExtensionDescriptor SupportedExtensions { get; set; }
+        [JsonProperty("supportedExtensions")]
+        public ExtensionDescriptor[] SupportedExtensions { get; set; }
     }
     public class MDSMetadata
     {

--- a/fido2-net-lib/Objects/AttestationConveyance.cs
+++ b/fido2-net-lib/Objects/AttestationConveyance.cs
@@ -38,7 +38,7 @@ namespace Fido2NetLib.Objects
                 case "direct":
                     return Direct;
                 default:
-                    throw new InvalidOperationException("Could parse value");
+                    throw new InvalidOperationException("Could not parse value");
             }
         }
     }

--- a/fido2-net-lib/Objects/AuthenticatorAttachment.cs
+++ b/fido2-net-lib/Objects/AuthenticatorAttachment.cs
@@ -28,5 +28,18 @@ namespace Fido2NetLib.Objects
         private AuthenticatorAttachment(string value) : base(value)
         {
         }
+
+        public static AuthenticatorAttachment Parse(string value)
+        {
+            switch (value)
+            {
+                case "platform":
+                    return Platform;
+                case "cross-platform":
+                    return CrossPlatform;
+                default:
+                    throw new InvalidOperationException("Could not parse value");
+            }
+        }
     }
 }

--- a/fido2-net-lib/Objects/PublicKeyCredentialDescriptor.cs
+++ b/fido2-net-lib/Objects/PublicKeyCredentialDescriptor.cs
@@ -16,17 +16,20 @@ namespace Fido2NetLib.Objects
         /// <summary>
         /// This member contains the type of the public key credential the caller is referring to.
         /// </summary>
+        [JsonProperty("type")]
         public string Type { get; set; } = "public-key";
 
         /// <summary>
         /// This member contains the credential ID of the public key credential the caller is referring to.
         /// </summary>
         [JsonConverter(typeof(Base64UrlConverter))]
+        [JsonProperty("id")]
         public byte[] Id { get; set; }
 
         /// <summary>
         /// This OPTIONAL member contains a hint as to how the client might communicate with the managing authenticator of the public key credential the caller is referring to.
         /// </summary>
+        [JsonProperty("transports")]
         public AuthenticatorTransport[] Transports { get; set; } = new AuthenticatorTransport[] { };
 
         public PublicKeyCredentialDescriptor(byte[] credentialId)


### PR DESCRIPTION
1. Authenticator type selection - ability to specify platform or cross-platform authenticators in addition to the current always null AuthenticatorSelection instance passed to RequestNewCredential. In the future, RequireResidentKey and UserVerification requirements can be added as well

2. Web browsers support detection - detect whether WebAuthn is supported and display an error/warning if not (does not work in IE because arrow function notations are used in webauthn.js)

3. Result classes JSON properties improvements - added missing JSONProperty attributes that I had problems with on client side in different environment) and fixed some in MetadataService (lowercase letter first, etc.)