### PR TITLE
Swappable MDS

### DIFF
--- a/Fido2Demo/Controller.cs
+++ b/Fido2Demo/Controller.cs
@@ -26,11 +26,12 @@ namespace Fido2Demo
 
         public MyController(IConfiguration config)
         {
-            _lib = new Fido2(new Fido2.Configuration
+            _lib = new Fido2(new Fido2.Configuration()
             {
                 ServerDomain = config["fido2:serverDomain"],
                 ServerName = "Fido2 test",
-                Origin = config["fido2:origin"]
+                Origin = config["fido2:origin"],
+                MetadataService = MDSMetadata.Instance(config["fido2:MDSAccessKey"], config["fido2:MDSCacheDir"])
             });
         }
 

--- a/Fido2Demo/Controller.cs
+++ b/Fido2Demo/Controller.cs
@@ -31,7 +31,7 @@ namespace Fido2Demo
                 ServerDomain = config["fido2:serverDomain"],
                 ServerName = "Fido2 test",
                 Origin = config["fido2:origin"],
-                MetadataService = MDSMetadata.Instance(config["fido2:MDSAccessKey"], config["fido2:MDSCacheDir"])
+                MetadataService = MDSMetadata.Instance(config["fido2:MDSAccessKey"], config["fido2:MDSCacheDirPath"])
             });
         }
 

--- a/Fido2Demo/Fido2Demo.csproj
+++ b/Fido2Demo/Fido2Demo.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <UserSecretsId>25a6110a-0f77-440c-a747-e8aa31be258d</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />

--- a/Fido2Demo/TestController.cs
+++ b/Fido2Demo/TestController.cs
@@ -35,7 +35,7 @@ namespace Fido2Demo
                 ServerDomain = config["fido2:serverDomain"],
                 ServerName = "Fido2 test",
                 Origin = config["fido2:origin"],
-                MetadataService = MDSMetadata.Instance(config["fido2:MDSAccessKey"], config["fido2:MDSCacheDir"])
+                MetadataService = MDSMetadata.Instance(config["fido2:MDSAccessKey"], config["fido2:MDSCacheDirPath"])
             });
         }
 

--- a/Fido2Demo/TestController.cs
+++ b/Fido2Demo/TestController.cs
@@ -30,11 +30,12 @@ namespace Fido2Demo
 
         public TestController(IConfiguration config)
         {
-            _lib = new Fido2(new Fido2NetLib.Fido2.Configuration
+            _lib = new Fido2(new Fido2NetLib.Fido2.Configuration()
             {
                 ServerDomain = config["fido2:serverDomain"],
                 ServerName = "Fido2 test",
-                Origin = config["fido2:origin"]
+                Origin = config["fido2:origin"],
+                MetadataService = MDSMetadata.Instance(config["fido2:MDSAccessKey"], config["fido2:MDSCacheDir"])
             });
         }
 

--- a/fido2-net-lib.Test/UnitTest1.cs
+++ b/fido2-net-lib.Test/UnitTest1.cs
@@ -103,14 +103,8 @@ namespace fido2_net_lib.Test
             var options = JsonConvert.DeserializeObject<CredentialCreateOptions>(File.ReadAllText("./AttestationNoneOptions.json"));
             var response = JsonConvert.DeserializeObject<AuthenticatorAttestationRawResponse>(File.ReadAllText("./AttestationNoneResponse.json"));
 
-            var fido2 = new Fido2NetLib.Fido2(new Fido2NetLib.Fido2.Configuration()
-            {
-                ServerDomain = "localhost",
-                Origin = "https://localhost:44329",
-            });
-
             var o = AuthenticatorAttestationResponse.Parse(response);
-            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null);
+            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null, null);
 
             var credId = "F1-3C-7F-08-3C-A2-29-E0-B4-03-E8-87-34-6E-FC-7F-98-53-10-3A-30-91-75-67-39-7A-D1-D8-AF-87-04-61-87-EF-95-31-85-60-F3-5A-1A-2A-CF-7D-B0-1D-06-B9-69-F9-AB-F4-EC-F3-07-3E-CF-0F-71-E8-84-E8-41-20";
             var allowedCreds = new List<PublicKeyCredentialDescriptor>() {
@@ -142,9 +136,8 @@ namespace fido2_net_lib.Test
 
             Assert.NotNull(jsonPost);
 
-            var fido2 = new Fido2NetLib.Fido2(new Fido2NetLib.Fido2.Configuration());
             var o = AuthenticatorAttestationResponse.Parse(jsonPost);
-            await o.VerifyAsync(options, "https://localhost:44329", isCredentialIdUniqueToUser: (x) => Task.FromResult(true), requestTokenBindingId: null);
+            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null, null);
         }
 
         [Fact]
@@ -162,9 +155,8 @@ namespace fido2_net_lib.Test
         {
             var jsonPost = JsonConvert.DeserializeObject<AuthenticatorAttestationRawResponse>(File.ReadAllText("./attestationResultsU2F.json"));
             var options = JsonConvert.DeserializeObject<CredentialCreateOptions>(File.ReadAllText("./attestationOptionsU2F.json"));
-            var fido2 = new Fido2NetLib.Fido2(new Fido2NetLib.Fido2.Configuration());
             var o = AuthenticatorAttestationResponse.Parse(jsonPost);
-            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null);
+            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null, null);
             byte[] ad = o.AttestationObject.AuthData;
         }
         [Fact]
@@ -172,9 +164,8 @@ namespace fido2_net_lib.Test
         {
             var jsonPost = JsonConvert.DeserializeObject<AuthenticatorAttestationRawResponse>(File.ReadAllText("./attestationResultsPacked.json"));
             var options = JsonConvert.DeserializeObject<CredentialCreateOptions>(File.ReadAllText("./attestationOptionsPacked.json"));
-            var fido2 = new Fido2NetLib.Fido2(new Fido2NetLib.Fido2.Configuration());
             var o = AuthenticatorAttestationResponse.Parse(jsonPost);
-            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null);
+            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null, null);
             byte[] ad = o.AttestationObject.AuthData;
         }
         [Fact]
@@ -182,18 +173,16 @@ namespace fido2_net_lib.Test
         {
             var jsonPost = JsonConvert.DeserializeObject<AuthenticatorAttestationRawResponse>(File.ReadAllText("./attestationResultsNone.json"));
             var options = JsonConvert.DeserializeObject<CredentialCreateOptions>(File.ReadAllText("./attestationOptionsNone.json"));
-            var fido2 = new Fido2NetLib.Fido2(new Fido2NetLib.Fido2.Configuration());
             var o = AuthenticatorAttestationResponse.Parse(jsonPost);
-            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null);
+            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null, null);
         }
         [Fact]
         public async Task TestTPMSHA256AttestationAsync()
         {
             var jsonPost = JsonConvert.DeserializeObject<AuthenticatorAttestationRawResponse>(File.ReadAllText("./attestationTPMSHA256Response.json"));
             var options = JsonConvert.DeserializeObject<CredentialCreateOptions>(File.ReadAllText("./attestationTPMSHA256Options.json"));
-            var fido2 = new Fido2NetLib.Fido2(new Fido2NetLib.Fido2.Configuration());
             var o = AuthenticatorAttestationResponse.Parse(jsonPost);
-            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null);
+            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null, null);
             byte[] ad = o.AttestationObject.AuthData;
         }
         [Fact]
@@ -201,9 +190,8 @@ namespace fido2_net_lib.Test
         {
             var jsonPost = JsonConvert.DeserializeObject<AuthenticatorAttestationRawResponse>(File.ReadAllText("./attestationTPMSHA1Response.json"));
             var options = JsonConvert.DeserializeObject<CredentialCreateOptions>(File.ReadAllText("./attestationTPMSHA1Options.json"));
-            var fido2 = new Fido2NetLib.Fido2(new Fido2NetLib.Fido2.Configuration());
             var o = AuthenticatorAttestationResponse.Parse(jsonPost);
-            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null);
+            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null, null);
             byte[] ad = o.AttestationObject.AuthData;
         }
         [Fact]
@@ -211,9 +199,8 @@ namespace fido2_net_lib.Test
         {
             var jsonPost = JsonConvert.DeserializeObject<AuthenticatorAttestationRawResponse>(File.ReadAllText("./attestationAndroidKeyResponse.json"));
             var options = JsonConvert.DeserializeObject<CredentialCreateOptions>(File.ReadAllText("./attestationAndroidKeyOptions.json"));
-            var fido2 = new Fido2NetLib.Fido2(new Fido2NetLib.Fido2.Configuration());
             var o = AuthenticatorAttestationResponse.Parse(jsonPost);
-            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null);
+            await o.VerifyAsync(options, "https://localhost:44329", (x) => Task.FromResult(true), null, null);
             byte[] ad = o.AttestationObject.AuthData;
         }
         //public void TestHasCorrentAAguid()

--- a/fido2-net-lib/AuthenticatorAttestationResponse.cs
+++ b/fido2-net-lib/AuthenticatorAttestationResponse.cs
@@ -61,7 +61,7 @@ namespace Fido2NetLib
             return response;
         }
 
-        public async Task<AttestationVerificationSuccess> VerifyAsync(CredentialCreateOptions originalOptions, string expectedOrigin, IsCredentialIdUniqueToUserAsyncDelegate isCredentialIdUniqueToUser, byte[] requestTokenBindingId)
+        public async Task<AttestationVerificationSuccess> VerifyAsync(CredentialCreateOptions originalOptions, string expectedOrigin, IsCredentialIdUniqueToUserAsyncDelegate isCredentialIdUniqueToUser, IMetadataService metadataService, byte[] requestTokenBindingId)
         {
             AttestationType attnType;
             X509Certificate2[] trustPath = null;
@@ -532,14 +532,10 @@ namespace Fido2NetLib
             // use aaguid (authData.AttData.Aaguid) to find root certs in metadata
             // use root plus trustPath to build trust chain
             
-            MetadataTOCPayloadEntry entry = null;
-            var metadata = MDSMetadata.Instance();
-            if (null != metadata)
+            if (null != metadataService)
             {
-                if (true == metadata.payload.ContainsKey(authData.AttData.GuidAaguid))
-                { 
-                    entry = metadata.payload[authData.AttData.GuidAaguid];
-                }
+                MetadataTOCPayloadEntry entry = metadataService.GetEntry(authData.AttData.GuidAaguid);
+                
                 if (null != entry)
                 {
                     if (entry.Hash != entry.MetadataStatement.Hash) throw new Fido2VerificationException("Authenticator metadata statement has invalid hash");

--- a/fido2-net-lib/Fido2NetLib.cs
+++ b/fido2-net-lib/Fido2NetLib.cs
@@ -43,6 +43,23 @@ namespace Fido2NetLib
             /// Server origin, including protocol host and port.
             /// </summary>
             public string Origin { get; set; }
+
+            /// <summary>
+            /// MetdataService to verify metadata statements https://fidoalliance.org/specs/fido-v2.0-rd-20180702/fido-metadata-service-v2.0-rd-20180702.html
+            /// </summary>
+            public IMetadataService MetadataService { get; set; }
+
+            /// <summary>
+            /// Create the configuration for Fido2
+            /// </summary>
+            public Configuration()
+            {
+            }
+
+            public Configuration(IMetadataService metadataService)
+            {
+                MetadataService = metadataService;
+            }
         }
 
         private Configuration Config { get; }
@@ -90,7 +107,7 @@ namespace Fido2NetLib
         public async Task<CredentialMakeResult> MakeNewCredentialAsync(AuthenticatorAttestationRawResponse attestationResponse, CredentialCreateOptions origChallenge, IsCredentialIdUniqueToUserAsyncDelegate isCredentialIdUniqueToUser, byte[] requestTokenBindingId = null)
         {
             var parsedResponse = AuthenticatorAttestationResponse.Parse(attestationResponse);
-            var success = await parsedResponse.VerifyAsync(origChallenge, Config.Origin, isCredentialIdUniqueToUser, requestTokenBindingId);
+            var success = await parsedResponse.VerifyAsync(origChallenge, Config.Origin, isCredentialIdUniqueToUser, Config.MetadataService, requestTokenBindingId);
 
             // todo: Set Errormessage etc.
             return new CredentialMakeResult { Status = "ok", ErrorMessage = string.Empty, Result = success };

--- a/fido2-net-lib/MetadataService.cs
+++ b/fido2-net-lib/MetadataService.cs
@@ -518,7 +518,7 @@ namespace Fido2NetLib
             {
                 if (null != entry.AaGuid)
                 {
-                    entry.MetadataStatement = GetMetadataStatement(entry, true);
+                    entry.MetadataStatement = GetMetadataStatement(entry, fromCache);
                     payload.Add(new System.Guid(entry.AaGuid), entry);
                 }
             }

--- a/fido2-net-lib/MetadataService.cs
+++ b/fido2-net-lib/MetadataService.cs
@@ -370,14 +370,20 @@ namespace Fido2NetLib
             // If the payload count is zero, we've failed to load metadata
             if (0 == payload.Count) throw new Fido2VerificationException("Failed to load MDS metadata");
         }
-        public static IMetadataService Instance(string accesskey, string cachedir)
+        /// <summary>
+        /// Returns or creates an instance of the MetadataSerivce. The paramters will only be used when the singleton is not alreayd created.
+        /// </summary>
+        /// <param name="accesskey"></param>
+        /// <param name="cachedirPath"></param>
+        /// <returns></returns>
+        public static IMetadataService Instance(string accesskey, string cachedirPath)
         {
             if (null == mDSMetadata)
             {
                 lock (syncRoot)
                 {
                     if (null == mDSMetadata)
-                        mDSMetadata = new MDSMetadata(accesskey, cachedir);
+                        mDSMetadata = new MDSMetadata(accesskey, cachedirPath);
                 }
             }
             return mDSMetadata;


### PR DESCRIPTION
A concept for swappable MDS.

This implementation is "unsafe but easy" by default. The default constructor of Configuration sets the MetdataService to null which is unsafe, but easy to get started.

I'm wondering if this is OK, given that we make it very clear in all examples / documents that you should set the Metadataservice (as shown in the examples in this PR).

I also changed the name of the AppSecrets to follow the standard used by our other variables.