### PR TITLE
Removed net462 from test project

### DIFF
--- a/fido2-net-lib.Test/fido2-net-lib.Test.csproj
+++ b/fido2-net-lib.Test/fido2-net-lib.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Running ```dotnet test`` generates a bunch of errors if net462 is targeted.

