### PR TITLE
Added a guarding mechanism to prevent usage in .NET46X

### DIFF
--- a/docs/NET46X.md
+++ b/docs/NET46X.md
@@ -1,0 +1,22 @@
+# Compatibility with .NET Framework 4.6.1 and 4.6.2
+
+When .NET Standard 2.0 was introduced, .NET Framework 4.6.1 and 4.6.2 were already out.
+Because the .NET 4.6.X Sku was the most stable release back then, the .NET Foundation decided
+it was worth breaking the theme of the .NET Standard a little and declare .NET 4.6.1 and 4.6.2 as
+.NET Standard 2.0 compatible even though there were some exotic APIs missing.
+
+This was done under the assumption that these APIs are not that commonly used, such that incompatibility
+would not make much problems.
+While the underlying assumption holds true to this today, Fido2 uses several of these APIs.
+
+See the official documentation regarding this issue for more information: <https://github.com/dotnet/standard/tree/master/docs/planning/netstandard-2.0#net-framework-461-supporting-net-standard-20>
+
+## Consequences for FIDO2
+
+For us this means that when consuming this package in a .NET 4.6.1 or 4.6.2 targeting project, at runtime you will see
+TypeLoadExceptions for types like "ECPoint" - essentially breaking the functionality of this library.
+
+## FI0404
+
+Because NuGet doesn't give us the ability to reduce these frameworks from the .NET Standard restore graphs,
+we have to fall back to MSBuild errors preventing you to even build a project with the offending configurations.

--- a/fido2-net-lib/Fido2NetLib.csproj
+++ b/fido2-net-lib/Fido2NetLib.csproj
@@ -29,4 +29,8 @@
     
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="build/fido2.targets" PackagePath="build/" />
+  </ItemGroup>
 </Project>

--- a/fido2-net-lib/build/fido2.targets
+++ b/fido2-net-lib/build/fido2.targets
@@ -1,0 +1,10 @@
+<Project>
+  <Target Name="ErrorForFrameworksMissingNETStandardAPIs" 
+          BeforeTargets="BeforeCompile"
+          Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462'">
+    <Error  Code="FI0404"
+            File="$(MSBuildProjectFullPath)"
+            Text="FIDO2 cannot be used with .NET 4.6.1 and .NET 4.6.2 due to missing APIs. %0a%0d
+                  Visit https://github.com/abergs/fido2-net-lib/blob/master/docs/NET46X.md for more information." />
+  </Target>
+</Project>


### PR DESCRIPTION

Because of compatibility issues with .NET Standard 2.0 we have to make sure
there is a sane way for customers to learn that this package does not work with
.NET Framework 4.6.X Skus.