### PR TITLE
Properties of PublicKeyCredentialType enum are nullable

### DIFF
--- a/fido2-net-lib/AuthenticatorAssertionRawResponse.cs
+++ b/fido2-net-lib/AuthenticatorAssertionRawResponse.cs
@@ -17,7 +17,7 @@ namespace Fido2NetLib
 
         public AssertionResponse Response { get; set; }
 
-        public PublicKeyCredentialType Type { get; set; }
+        public PublicKeyCredentialType? Type { get; set; }
 
         public class AssertionResponse
         {

--- a/fido2-net-lib/AuthenticatorAttestationRawResponse.cs
+++ b/fido2-net-lib/AuthenticatorAttestationRawResponse.cs
@@ -14,7 +14,7 @@ namespace Fido2NetLib
         [JsonConverter(typeof(Base64UrlConverter))]
         public byte[] RawId { get; set; }
 
-        public PublicKeyCredentialType Type { get; set; }
+        public PublicKeyCredentialType? Type { get; set; }
 
         public ResponseData Response { get; set; }
 

--- a/fido2-net-lib/Objects/PublicKeyCredentialDescriptor.cs
+++ b/fido2-net-lib/Objects/PublicKeyCredentialDescriptor.cs
@@ -13,7 +13,7 @@ namespace Fido2NetLib.Objects
         /// This member contains the type of the public key credential the caller is referring to.
         /// </summary>
         [JsonProperty("type")]
-        public PublicKeyCredentialType Type { get; set; } = PublicKeyCredentialType.PublicKey;
+        public PublicKeyCredentialType? Type { get; set; } = PublicKeyCredentialType.PublicKey;
 
         /// <summary>
         /// This member contains the credential ID of the public key credential the caller is referring to.


### PR DESCRIPTION
Allow nulls in properties of PublicKeyCredentialType enum as mentioned [here](https://github.com/abergs/fido2-net-lib/pull/69#issuecomment-453638318).