### PR TITLE
Support Target Frameworks by OS

### DIFF
--- a/fido2-net-lib/Fido2NetLib.csproj
+++ b/fido2-net-lib/Fido2NetLib.csproj
@@ -4,7 +4,8 @@
   <Import Project="../lib/Asn1Processor/Asn1Processor.Include.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard2.0;net472;netcoreapp2.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
A pending PR. Allows building in macOS and Linux otherwise, the compiler will argue about the missing .NET Framework 4.7.2 SDK in those platforms.