### PR TITLE
Wrong naming of attestationObject and clientDataJSON in usernameless.…

### DIFF
--- a/Demo/wwwroot/js/usernameless.register.js
+++ b/Demo/wwwroot/js/usernameless.register.js
@@ -127,8 +127,8 @@ async function registerNewCredential(newCredential) {
         type: newCredential.type,
         extensions: newCredential.getClientExtensionResults(),
         response: {
-            AttestationObject: coerceToBase64Url(attestationObject),
-            clientDataJson: coerceToBase64Url(clientDataJSON)
+            attestationObject: coerceToBase64Url(attestationObject),
+            clientDataJSON: coerceToBase64Url(clientDataJSON)
         }
     };
 


### PR DESCRIPTION
…register.js

During implementation and using this lib, i found these two anomalies vs the specs.
Lookup up the names on the specs: https://www.w3.org/TR/webauthn/#iface-authenticatorattestationresponse
AttestationObject -> attestationObject
and
clientDataJson -> clientDataJSON

PS I did not check on the server side (I'm not a .net dev),  if the server is handled correctly or if that needs an update too. My guess is it needs. Could some .NET wiz please check this and update the code if things fail at the back end? Many thanks in advance.