### PR TITLE
Out of spec typo on clientDataJson -> clientDataJSON

### DIFF
--- a/Demo/wwwroot/js/usernameless.login.js
+++ b/Demo/wwwroot/js/usernameless.login.js
@@ -90,7 +90,7 @@ async function verifyAssertionWithServer(assertedCredential) {
         extensions: assertedCredential.getClientExtensionResults(),
         response: {
             authenticatorData: coerceToBase64Url(authData),
-            clientDataJson: coerceToBase64Url(clientDataJSON),
+            clientDataJSON: coerceToBase64Url(clientDataJSON),
             signature: coerceToBase64Url(sig)
         }
     };


### PR DESCRIPTION
Specs on https://www.w3.org/TR/webauthn/ 
use the clientDataJSON not the clientDataJson
See change in file. This is in the demo usernameless.register.js
I know it's just details but it's an API the W3C docs are pretty strict in ;-)