### PR TITLE
Add field userHandle in verifyAssertionWithServer

### DIFF
--- a/Demo/wwwroot/js/usernameless.login.js
+++ b/Demo/wwwroot/js/usernameless.login.js
@@ -83,6 +83,7 @@ async function verifyAssertionWithServer(assertedCredential) {
     let clientDataJSON = new Uint8Array(assertedCredential.response.clientDataJSON);
     let rawId = new Uint8Array(assertedCredential.rawId);
     let sig = new Uint8Array(assertedCredential.response.signature);
+    let userHandle = new Uint8Array(assertedCredential.response.userHandle)
     const data = {
         id: assertedCredential.id,
         rawId: coerceToBase64Url(rawId),

--- a/Demo/wwwroot/js/usernameless.login.js
+++ b/Demo/wwwroot/js/usernameless.login.js
@@ -91,6 +91,7 @@ async function verifyAssertionWithServer(assertedCredential) {
         response: {
             authenticatorData: coerceToBase64Url(authData),
             clientDataJson: coerceToBase64Url(clientDataJSON),
+            userHandle: userHandle !== null ? coerceToBase64Url(userHandle): null,
             signature: coerceToBase64Url(sig)
         }
     };


### PR DESCRIPTION
For the usernamaless result on the client side, the **userHandle** was missing in the reply. 
This can be _nullable_, but not missing since it is even backwards compatible according to: https://www.w3.org/TR/webauthn/#conforming-authenticators-u2f

however: FIDO2 BtB (by the book ;-)
Quote from: 
https://www.w3.org/TR/webauthn/#discover-from-external-source 
step: "->If any authenticator indicates success."

**userHandleResult**
If the authenticator returned a _user handle_, set the value of **userHandleResult** to be the bytes of the returned user handle. Otherwise, set the value of **userHandleResult** to **null**.

I'm no .NET guy, so haven't checked what impact this field has on the backend when it suddenly appears. I presume 'nothing' but not sure. If someone else could please test that out for me. Many thanks!