### PR TITLE
corrected error variable

### DIFF
--- a/Demo/wwwroot/js/custom.register.js
+++ b/Demo/wwwroot/js/custom.register.js
@@ -91,8 +91,7 @@ async function handleRegisterSubmit(event) {
 
     try {
         registerNewCredential(newCredential);
-
-    } catch (e) {
+    } catch (err) {
         showErrorAlert(err.message ? err.message : err);
     }
 }


### PR DESCRIPTION
I just changed the catched error variable from "e" to "err", so it gets used in the line below to show the error message.