### PR TITLE
EdDSA test, sign the actual data, not a hash of the data

### DIFF
--- a/Test/UnitTest1.cs
+++ b/Test/UnitTest1.cs
@@ -510,7 +510,6 @@ namespace fido2_net_lib.Test
                     }
                 case COSE.KeyType.OKP:
                     {
-                        data = CryptoUtils.GetHasher(HashAlgorithmName.SHA512).ComputeHash(data);
                         signature = Chaos.NaCl.Ed25519.Sign(data, expandedPrivateKey);
                         break;
                     }


### PR DESCRIPTION
Corresponds to recent conformance tool change in EdDSA signature validation handling.