### PR TITLE
Remove CNG dependencies to allow cross platform scenarios

### DIFF
--- a/Demo/TestController.cs
+++ b/Demo/TestController.cs
@@ -37,7 +37,7 @@ namespace Fido2Demo
                 ServerDomain = config["fido2:serverDomain"],
                 ServerName = "Fido2 test",
                 Origin = _origin
-            }, ConformanceTesting.MetadataServiceInstance(config["fido2:MDSCacheDirPath"] + @"\Conformance", _origin));
+            }, ConformanceTesting.MetadataServiceInstance(System.IO.Path.Combine(config["fido2:MDSCacheDirPath"], @"Conformance"), _origin));
         }
 
         [HttpPost]

--- a/Src/Fido2/AttestationFormat/AndroidKey.cs
+++ b/Src/Fido2/AttestationFormat/AndroidKey.cs
@@ -222,11 +222,11 @@ namespace Fido2NetLib.AttestationFormat
                 throw new Fido2VerificationException("Malformed x5c in android-key attestation");
 
             X509Certificate2 androidKeyCert;
-            ECDsaCng androidKeyPubKey;
+            ECDsa androidKeyPubKey;
             try
             {
                 androidKeyCert = new X509Certificate2(X5c.Values.First().GetByteString());
-                androidKeyPubKey = (ECDsaCng)androidKeyCert.GetECDsaPublicKey(); // attestation public key
+                androidKeyPubKey = androidKeyCert.GetECDsaPublicKey(); // attestation public key
             }
             catch (Exception ex)
             {

--- a/Src/Fido2/AttestationFormat/FidoU2f.cs
+++ b/Src/Fido2/AttestationFormat/FidoU2f.cs
@@ -72,7 +72,7 @@ namespace Fido2NetLib.AttestationFormat
             // 2b. If certificate public key is not an Elliptic Curve (EC) public key over the P-256 curve, terminate this algorithm and return an appropriate error
             var pubKey = cert.GetECDsaPublicKey();
             var keyParams = pubKey.ExportParameters(false);
-            if (!keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP256.Oid.Value))
+            if (!keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP256.Oid.FriendlyName))
                 throw new Fido2VerificationException("Attestation certificate public key is not an Elliptic Curve (EC) public key over the P-256 curve");
 
             // 3. Extract the claimed rpIdHash from authenticatorData, and the claimed credentialId and credentialPublicKey from authenticatorData

--- a/Src/Fido2/AttestationFormat/FidoU2f.cs
+++ b/Src/Fido2/AttestationFormat/FidoU2f.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Fido2NetLib.Objects;
@@ -72,9 +73,18 @@ namespace Fido2NetLib.AttestationFormat
             // 2b. If certificate public key is not an Elliptic Curve (EC) public key over the P-256 curve, terminate this algorithm and return an appropriate error
             var pubKey = cert.GetECDsaPublicKey();
             var keyParams = pubKey.ExportParameters(false);
-            if (!keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP256.Oid.FriendlyName))
-                throw new Fido2VerificationException("Attestation certificate public key is not an Elliptic Curve (EC) public key over the P-256 curve");
 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (!keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP256.Oid.FriendlyName))
+                    throw new Fido2VerificationException("Attestation certificate public key is not an Elliptic Curve (EC) public key over the P-256 curve");
+            }
+
+            else
+            {
+                if (!keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP256.Oid.Value))
+                    throw new Fido2VerificationException("Attestation certificate public key is not an Elliptic Curve (EC) public key over the P-256 curve");
+            }
             // 3. Extract the claimed rpIdHash from authenticatorData, and the claimed credentialId and credentialPublicKey from authenticatorData
             // see rpIdHash, credentialId, and credentialPublicKey variables
 

--- a/Src/Fido2/AttestationFormat/FidoU2f.cs
+++ b/Src/Fido2/AttestationFormat/FidoU2f.cs
@@ -70,8 +70,9 @@ namespace Fido2NetLib.AttestationFormat
             }
 
             // 2b. If certificate public key is not an Elliptic Curve (EC) public key over the P-256 curve, terminate this algorithm and return an appropriate error
-            var pubKey = (ECDsaCng)cert.GetECDsaPublicKey();
-            if (CngAlgorithm.ECDsaP256 != pubKey.Key.Algorithm)
+            var pubKey = cert.GetECDsaPublicKey();
+            var keyParams = pubKey.ExportParameters(false);
+            if (!keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP256.Oid.Value))
                 throw new Fido2VerificationException("Attestation certificate public key is not an Elliptic Curve (EC) public key over the P-256 curve");
 
             // 3. Extract the claimed rpIdHash from authenticatorData, and the claimed credentialId and credentialPublicKey from authenticatorData

--- a/Src/Fido2/AttestationFormat/Packed.cs
+++ b/Src/Fido2/AttestationFormat/Packed.cs
@@ -81,7 +81,7 @@ namespace Fido2NetLib.AttestationFormat
 
                 // 2a. Verify that sig is a valid signature over the concatenation of authenticatorData and clientDataHash 
                 // using the attestation public key in attestnCert with the algorithm specified in alg
-                var packedPubKey = (ECDsaCng)attestnCert.GetECDsaPublicKey(); // attestation public key
+                var packedPubKey = attestnCert.GetECDsaPublicKey(); // attestation public key
                 if (false == CryptoUtils.algMap.ContainsKey(Alg.AsInt32()))
                     throw new Fido2VerificationException("Invalid attestation algorithm");
 

--- a/Src/Fido2/AttestationFormat/Tpm.cs
+++ b/Src/Fido2/AttestationFormat/Tpm.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Fido2NetLib.Objects;
@@ -530,6 +531,13 @@ namespace Fido2NetLib.AttestationFormat
                 // Attributes. In accordance with RFC 5280[11], this extension MUST be critical if subject is empty 
                 // and SHOULD be non-critical if subject is non-empty"
 
+                // AsnEncodedData does this for us on Windows
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    SAN = SAN.Replace("2.23.133.2.1", "TPMManufacturer")
+                        .Replace("2.23.133.2.2", "TPMModel")
+                        .Replace("2.23.133.2.3", "TPMVersion");
+                }
                 // Best I can figure to do for now?
                 if (false == SAN.Contains("TPMManufacturer") ||
                     false == SAN.Contains("TPMModel") ||

--- a/Src/Fido2/AuthenticatorResponse.cs
+++ b/Src/Fido2/AuthenticatorResponse.cs
@@ -61,7 +61,7 @@ namespace Fido2NetLib
                 throw new Fido2VerificationException("Challenge not equal to original challenge");
 
             if (Origin != expectedOrigin)
-                throw new Fido2VerificationException("Origin not equal to original origin");
+                throw new Fido2VerificationException($"Origin {Origin} not equal to original origin {expectedOrigin}");
 
             if (Type != "webauthn.create" && Type != "webauthn.get")
                 throw new Fido2VerificationException($"Type not equal to 'webauthn.create' or 'webauthn.get'. Was: '{Type}'");

--- a/Src/Fido2/CryptoUtils.cs
+++ b/Src/Fido2/CryptoUtils.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Fido2NetLib.Objects;
@@ -167,8 +168,17 @@ namespace Fido2NetLib
             {
                 if (ext.Oid.Value.Equals("2.5.29.31")) // id-ce-CRLDistributionPoints
                 {
-                    var asnData = new AsnEncodedData(ext.Oid, ext.RawData);
-                    cdp += asnData.Format(false).Split('=')[1];
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        var asnData = new AsnEncodedData(ext.Oid, ext.RawData);
+                        cdp += asnData.Format(false).Split('=')[1];
+                    }
+                    else
+                    {
+                        var strCDP = Asn1Util.BytesToString(ext.RawData);
+                        strCDP = strCDP.Replace("\u0086.", "=");
+                        cdp += strCDP.Split('=')[1];
+                    }
                 }
             }
             return cdp;

--- a/Src/Fido2/Objects/CredentialPublicKey.cs
+++ b/Src/Fido2/Objects/CredentialPublicKey.cs
@@ -41,19 +41,19 @@ namespace Fido2NetLib.Objects
             }
             if (COSE.KeyType.EC2 == _type)
             {
-                var ecDsaPubKey = (ECDsaCng)cert.GetECDsaPublicKey();
+                var ecDsaPubKey = cert.GetECDsaPublicKey();
                 var keyParams = ecDsaPubKey.ExportParameters(false);
 
-                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP256.Oid.FriendlyName))
+                if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP256.Oid.Value))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256);
 
-                if (keyParams.Curve.Oid.FriendlyName.Equals("secP256k1"))
+                if (keyParams.Curve.Oid.Value.Equals("1.3.132.0.10"))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256K);
 
-                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP384.Oid.FriendlyName))
+                if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP384.Oid.Value))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P384);
 
-                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP521.Oid.FriendlyName))
+                if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP521.Oid.Value))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P521);
 
                 _cpk.Add(COSE.KeyTypeParameter.X, keyParams.Q.X);
@@ -73,7 +73,7 @@ namespace Fido2NetLib.Objects
                     }
 
                 case COSE.KeyType.RSA:
-                    using (RSACng rsa = CreateRsa())
+                    using (RSA rsa = CreateRsa())
                     {
                         return rsa.VerifyData(data, sig, CryptoUtils.algMap[(int)_alg], Padding);
                     }
@@ -84,11 +84,11 @@ namespace Fido2NetLib.Objects
             throw new InvalidOperationException($"Missing or unknown kty {_type}");
         }
 
-        internal RSACng CreateRsa()
+        internal RSA CreateRsa()
         {
             if (_type == COSE.KeyType.RSA)
             {
-                var rsa = new RSACng();
+                var rsa = RSA.Create();
                 rsa.ImportParameters(
                     new RSAParameters()
                     {

--- a/Src/Fido2/Objects/CredentialPublicKey.cs
+++ b/Src/Fido2/Objects/CredentialPublicKey.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Chaos.NaCl;
@@ -44,17 +45,31 @@ namespace Fido2NetLib.Objects
                 var ecDsaPubKey = cert.GetECDsaPublicKey();
                 var keyParams = ecDsaPubKey.ExportParameters(false);
 
-                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP256.Oid.FriendlyName))
-                    _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256);
-
                 if (keyParams.Curve.Oid.FriendlyName.Equals("secP256k1"))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256K);
 
-                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP384.Oid.FriendlyName))
-                    _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P384);
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP256.Oid.FriendlyName))
+                        _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256);
 
-                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP521.Oid.FriendlyName))
-                    _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P521);
+                    if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP384.Oid.FriendlyName))
+                        _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P384);
+
+                    if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP521.Oid.FriendlyName))
+                        _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P521);
+                }
+                else
+                {
+                    if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP256.Oid.Value))
+                        _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256);
+
+                    if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP384.Oid.Value))
+                        _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P384);
+                    
+                    if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP521.Oid.Value))
+                        _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P521);
+                }
 
                 _cpk.Add(COSE.KeyTypeParameter.X, keyParams.Q.X);
                 _cpk.Add(COSE.KeyTypeParameter.Y, keyParams.Q.Y);

--- a/Src/Fido2/Objects/CredentialPublicKey.cs
+++ b/Src/Fido2/Objects/CredentialPublicKey.cs
@@ -44,16 +44,16 @@ namespace Fido2NetLib.Objects
                 var ecDsaPubKey = cert.GetECDsaPublicKey();
                 var keyParams = ecDsaPubKey.ExportParameters(false);
 
-                if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP256.Oid.Value))
+                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP256.Oid.FriendlyName))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256);
 
-                if (keyParams.Curve.Oid.Value.Equals("1.3.132.0.10"))
+                if (keyParams.Curve.Oid.FriendlyName.Equals("secP256k1"))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256K);
 
-                if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP384.Oid.Value))
+                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP384.Oid.FriendlyName))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P384);
 
-                if (keyParams.Curve.Oid.Value.Equals(ECCurve.NamedCurves.nistP521.Oid.Value))
+                if (keyParams.Curve.Oid.FriendlyName.Equals(ECCurve.NamedCurves.nistP521.Oid.FriendlyName))
                     _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P521);
 
                 _cpk.Add(COSE.KeyTypeParameter.X, keyParams.Q.X);


### PR DESCRIPTION
Resolves #70. Plus other cross-platform issues, mostly related AsnEncodedData working differently on Windows vs non-Windows.  Some ECCurve related things should be revisited if we move to .NET Core 3.