### PR TITLE
Upgrading project to remove EOL frameworks

### DIFF
--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -7,9 +7,8 @@
     <ProjectReference Include="..\Src\Fido2.AspNet\Fido2.AspNet.csproj" />
     <ProjectReference Include="..\Src\Fido2.Models\Fido2.Models.csproj" />
     <ProjectReference Include="..\Src\Fido2\Fido2.csproj" />
-
-    <PackageReference Include="Microsoft.AspNetCore.All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />    
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />

--- a/Demo/Properties/launchSettings.json
+++ b/Demo/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:4728/",
+      "applicationUrl": "http://localhost:44329/",
       "sslPort": 44329
     }
   },
@@ -20,7 +20,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:4729/"
+      "applicationUrl": "http://localhost:44329/"
     }
   }
 }

--- a/Demo/Startup.cs
+++ b/Demo/Startup.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Fido2NetLib;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -8,6 +10,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json.Converters;
 
 namespace Fido2Demo
 {
@@ -24,11 +28,14 @@ namespace Fido2Demo
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().AddRazorPagesOptions(o =>
+            services
+                .AddMvc(options => { options.EnableEndpointRouting = false; })
+                .AddNewtonsoftJson()
+                .AddRazorPagesOptions(o =>
             {
                 // we don't care about antiforgery in the demo
                 o.Conventions.ConfigureFilter(new IgnoreAntiforgeryTokenAttribute());
-            }); ;
+            });
 
             // Adds a default in-memory implementation of IDistributedCache.
             services.AddDistributedMemoryCache();
@@ -61,11 +68,11 @@ namespace Fido2Demo
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
-                app.UseBrowserLink();
+                //app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
             }
             else

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,9 +15,9 @@
   <!-- GLOBALLY USABLE VARIABLES -->
   <PropertyGroup>
     <!-- Establish a preset but make it an active choice for each project. -->
-    <SupportedNonMetaTargetFrameWorks>netcoreapp2.2</SupportedNonMetaTargetFrameWorks>
+    <SupportedNonMetaTargetFrameWorks>netcoreapp3.1</SupportedNonMetaTargetFrameWorks>
     <!-- Can't have test project target .netstandard - only implementations not metaframeworks -->
-    <SupportedTargetFrameworks>netstandard2.0;$(SupportedNonMetaTargetFrameWorks)</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks>netstandard2.0;netstandard2.1;$(SupportedNonMetaTargetFrameWorks)</SupportedTargetFrameworks>
   </PropertyGroup>
   <!-- Language + Compiler Settings-->
   <PropertyGroup>

--- a/Src/Fido2.AspNet/Fido2.AspNet.csproj
+++ b/Src/Fido2.AspNet/Fido2.AspNet.csproj
@@ -8,13 +8,17 @@
     <ProjectReference Include="..\Fido2\Fido2.csproj" />
     <ProjectReference Include="..\Fido2.Models\Fido2.Models.csproj" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
 
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Src/Fido2.AspNet/Fido2.AspNet.csproj
+++ b/Src/Fido2.AspNet/Fido2.AspNet.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
+    <Version>1.0.2</Version>
+    <PackageReleaseNotes>adding .net core 3.1 support and removing deprecated frameworks</PackageReleaseNotes>
+    <PackageLicenseUrl />
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Fido2.Models/Fido2.Models.csproj
+++ b/Src/Fido2.Models/Fido2.Models.csproj
@@ -12,6 +12,9 @@
     <Compile Remove="IMetadataService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/Src/Fido2.Models/Fido2.Models.csproj
+++ b/Src/Fido2.Models/Fido2.Models.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Version>1.0.2</Version>
+    <PackageReleaseNotes>adding .net core 3.1 support and removing deprecated frameworks</PackageReleaseNotes>
+    <PackageLicenseUrl />
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="MetadataStatements\**" />

--- a/Src/Fido2.Models/Metadata/MetadataStatement.cs
+++ b/Src/Fido2.Models/Metadata/MetadataStatement.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Dynamic;
+using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 
 namespace Fido2NetLib
 {
@@ -12,10 +16,11 @@ namespace Fido2NetLib
     public class MetadataStatement
     {
         /// <summary>
-        /// Gets or sets the legalHeader, if present, contains a legal guide for accessing and using metadata, which itself MAY contain URL(s) pointing to further information, such as a full Terms and Conditions statement. 
+        /// Gets or sets the legalHeader, if present, contains a legal guide for accessing and using metadata, which itself MAY contain URL(s) pointing to further information, such as a full Terms and Conditions statement.
         /// </summary>
         [JsonProperty("legalHeader")]
         public string LegalHeader { get; set; }
+
         /// <summary>
         /// Gets or set the Authenticator Attestation ID.
         /// </summary>
@@ -24,89 +29,123 @@ namespace Fido2NetLib
         /// </remarks>
         [JsonProperty("aaid")]
         public string Aaid { get; set; }
+
         /// <summary>
-        /// Gets or sets the Authenticator Attestation GUID. 
+        /// Gets or sets the Authenticator Attestation GUID.
         /// </summary>
         /// <remarks>
-        /// This field MUST be set if the authenticator implements FIDO 2. 
+        /// This field MUST be set if the authenticator implements FIDO 2.
         /// <para>Note: FIDO 2 Authenticators support AAGUID, but they don't support AAID.</para>
         /// </remarks>
         [JsonProperty("aaguid")]
         public string AaGuid { get; set; }
+
         /// <summary>
         /// Gets or sets a list of the attestation certificate public key identifiers encoded as hex string.
         /// </summary>
         [JsonProperty("attestationCertificateKeyIdentifiers")]
         public string[] AttestationCertificateKeyIdentifiers { get; set; }
+
         /// <summary>
-        /// Gets or sets a human-readable, short description of the authenticator, in English. 
+        /// Gets or sets a human-readable, short description of the authenticator, in English.
         /// </summary>
         [JsonProperty("description", Required = Required.Always)]
         public string Description { get; set; }
+
         /// <summary>
         /// Gets or set a list of human-readable short descriptions of the authenticator in different languages.
         /// </summary>
         [JsonProperty("alternativeDescriptions")]
         public AlternativeDescriptions IETFLanguageCodesMembers { get; set; }
+
         /// <summary>
-        /// Gets or set earliest (i.e. lowest) trustworthy authenticatorVersion meeting the requirements specified in this metadata statement. 
+        /// Gets or set earliest (i.e. lowest) trustworthy authenticatorVersion meeting the requirements specified in this metadata statement.
         /// </summary>
         [JsonProperty("authenticatorVersion")]
         public ushort AuthenticatorVersion { get; set; }
+
         /// <summary>
         /// Gets or set the FIDO protocol family.
         /// <para>The values "uaf", "u2f", and "fido2" are supported.</para>
         /// </summary>
         [JsonProperty("protocolFamily")]
         public string ProtocolFamily { get; set; }
+
+        //TODO: JsonConvert doesnt seem to behave correctly in this version of .net core. Therefore, we have to two-step the parsing of the version
+        [JsonProperty("upv")]
+        internal object[] Upv_backing { get; set; }
+
         /// <summary>
         /// Gets or sets the FIDO unified protocol version(s) (related to the specific protocol family) supported by this authenticator.
         /// </summary>
-        [JsonProperty("upv")]
-        public Version[] Upv { get; set; }
+        public Version[] Upv
+        {
+            get
+            {
+                return Upv_backing?.Select(x =>
+                {
+                    if (x == null)
+                        return (Version)null;
+                    var jToken = JValue.Parse(x.ToString());
+                    var vString = $"{jToken["major"]}.{jToken["minor"]}";
+                    return Version.Parse(vString);
+                }).ToArray();
+            }
+
+            set { Upv_backing = value?.Select(x => JToken.FromObject(new { major = x.Major, minor = x.Minor })).ToArray(); }
+        }
+
         /// <summary>
         /// Gets or sets the assertion scheme supported by the authenticator.
         /// </summary>
         [JsonProperty("assertionScheme")]
         public string AssertionScheme { get; set; }
+
         /// <summary>
         /// Gets or sets the preferred authentication algorithm supported by the authenticator.
         /// </summary>
         [JsonProperty("authenticationAlgorithm")]
         public ushort AuthenticationAlgorithm { get; set; }
+
         /// <summary>
-        /// Gets or sets the list of authentication algorithms supported by the authenticator. 
+        /// Gets or sets the list of authentication algorithms supported by the authenticator.
         /// </summary>
         [JsonProperty("authenticationAlgorithms")]
         public ushort[] AuthenticationAlgorithms { get; set; }
+
         /// <summary>
         /// Gets or sets the preferred public key format used by the authenticator during registration operations.
         /// </summary>
         [JsonProperty("publicKeyAlgAndEncoding")]
         public ushort PublicKeyAlgAndEncoding { get; set; }
+
         /// <summary>
         /// Gets or sets the list of public key formats supported by the authenticator during registration operations.
         /// </summary>
         [JsonProperty("publicKeyAlgAndEncodings")]
         public ushort[] PublicKeyAlgAndEncodings { get; set; }
+
         /// <summary>
         /// Gets or sets the supported attestation type(s).
         /// </summary>
         /// <remarks>
-        /// For example: TAG_ATTESTATION_BASIC_FULL(0x3E07), TAG_ATTESTATION_BASIC_SURROGATE(0x3E08). 
+        /// For example: TAG_ATTESTATION_BASIC_FULL(0x3E07), TAG_ATTESTATION_BASIC_SURROGATE(0x3E08).
         /// </remarks>
         [JsonProperty("attestationTypes")]
         public ushort[] AttestationTypes { get; set; }
+
         /// <summary>
         /// Gets or sets a list of alternative VerificationMethodANDCombinations.
         /// </summary>
         [JsonProperty("userVerificationDetails")]
         public VerificationMethodDescriptor[][] UserVerificationDetails { get; set; }
+
         /// <summary>
         /// Gets or sets a 16-bit number representing the bit fields defined by the KEY_PROTECTION constants.
         /// </summary>
         [JsonProperty("keyProtection")]
         public ushort KeyProtection { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether the Uauth private key is restricted by the authenticator to only sign valid FIDO signature assertions.
         /// </summary>
@@ -119,72 +158,86 @@ namespace Fido2NetLib
         /// </remarks>
         [JsonProperty("isKeyRestricted")]
         public bool IsKeyRestricted { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether the Uauth key usage always requires a fresh user verification.
         /// </summary>
         [JsonProperty("isFreshUserVerificationRequired")]
         public bool IsFreshUserVerificationRequired { get; set; }
+
         /// <summary>
         /// Gets or sets a 16-bit number representing the bit fields defined by the MATCHER_PROTECTION constants.
         /// </summary>
         [JsonProperty("matcherProtection")]
         public ushort MatcherProtection { get; set; }
+
         /// <summary>
         /// Gets or sets the authenticator's overall claimed cryptographic strength in bits (sometimes also called security strength or security level).
         /// </summary>
         /// <remarks>If this value is absent, the cryptographic strength is unknown.</remarks>
         [JsonProperty("cryptoStrength")]
         public ushort CryptoStrength { get; set; }
+
         /// <summary>
         /// Gets or sets a description of the particular operating environment that is used for the Authenticator.
         /// </summary>
         [JsonProperty("operatingEnv")]
         public string OperatingEnv { get; set; }
+
         /// <summary>
         /// Gets or sets a 32-bit number representing the bit fields defined by the ATTACHMENT_HINT constants.
         /// </summary>
         [JsonProperty("attachmentHint")]
         public ulong AttachmentHint { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether the authenticator is designed to be used only as a second factor, i.e. requiring some other authentication method as a first factor.
         /// </summary>
         [JsonProperty("isSecondFactorOnly")]
         public bool IsSecondFactorOnly { get; set; }
+
         /// <summary>
         /// Gets or sets a 16-bit number representing a combination of the bit flags defined by the TRANSACTION_CONFIRMATION_DISPLAY constants.
         /// </summary>
         [JsonProperty("tcDisplay")]
         public ushort TcDisplay { get; set; }
+
         /// <summary>
-        /// Gets or sets the supported MIME content type [RFC2049] for the transaction confirmation display, such as text/plain or image/png. 
+        /// Gets or sets the supported MIME content type [RFC2049] for the transaction confirmation display, such as text/plain or image/png.
         /// </summary>
         [JsonProperty("tcDisplayContentType")]
         public string TcDisplayContentType { get; set; }
+
         /// <summary>
         /// Gets or sets a list of alternative DisplayPNGCharacteristicsDescriptor.
         /// </summary>
         [JsonProperty("tcDisplayPNGCharacteristics")]
         public DisplayPNGCharacteristicsDescriptor[] TcDisplayPNGCharacteristics { get; set; }
+
         /// <summary>
         /// Gets or sets a list of a PKIX [RFC5280] X.509 certificate that is a valid trust anchor for this authenticator model.
         /// </summary>
         [JsonProperty("attestationRootCertificates")]
         public string[] AttestationRootCertificates { get; set; }
+
         /// <summary>
-        /// Gets or set a list of trust anchors used for ECDAA attestation. 
+        /// Gets or set a list of trust anchors used for ECDAA attestation.
         /// </summary>
         [JsonProperty("ecdaaTrustAnchors")]
         public EcdaaTrustAnchor[] EcdaaTrustAnchors { get; set; }
+
         /// <summary>
         /// Gets or set a data: url [RFC2397] encoded PNG [PNG] icon for the Authenticator.
         /// </summary>
         [JsonProperty("icon")]
         public string Icon { get; set; }
+
         /// <summary>
-        /// Gets or sets a list of extensions supported by the authenticator. 
+        /// Gets or sets a list of extensions supported by the authenticator.
         /// </summary>
         [JsonProperty("supportedExtensions")]
         public ExtensionDescriptor[] SupportedExtensions { get; set; }
+
         /// <summary>
         /// Gets or sets a computed hash value of this <see cref="MetadataStatement"/>.
         /// <para>NOTE: This supports the internal infrastructure of Fido2Net and isn't intented to be used by user code.</para>

--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -1,6 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
+    <PackageLicenseUrl />
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReleaseNotes>adding .net core 3.1 support and removing deprecated frameworks</PackageReleaseNotes>
+    <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <FileVersion>1.0.2.0</FileVersion>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <!-- Sourced Libraries -->
@@ -28,7 +34,7 @@
   <!-- Attach a build warning in relation to our .NETStandard2.0
    / NET46X missing APIs issue -->
   <ItemGroup>
-    <!-- 
+    <!--
       The name of the file must equal to the name of the package which is currently
       defaulting to the project file name (excluding file extension of course)...
     -->

--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -19,10 +19,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Fido2.Models\Fido2.Models.csproj" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
   </ItemGroup>
 
   <!-- Attach a build warning in relation to our .NETStandard2.0
@@ -33,5 +33,9 @@
       defaulting to the project file name (excluding file extension of course)...
     -->
     <Content Include="build/fido2.targets" PackagePath="build/" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="PeterO.Numbers" Version="1.5.1" />
   </ItemGroup>
 </Project>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -18,19 +18,15 @@
     <ProjectReference Include="..\Src\Fido2.AspNet\Fido2.AspNet.csproj" />
     <ProjectReference Include="..\Src\Fido2.Models\Fido2.Models.csproj" />
     <ProjectReference Include="..\Src\Fido2\Fido2.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection">
-      <HintPath>..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.dependencyinjection\2.2.0\lib\netcoreapp2.0\Microsoft.Extensions.DependencyInjection.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Updating the application to .net core 3.1 based on the guidelines defined [here](https://dotnet.microsoft.com/platform/support/policy/dotnet-core)

This updates the libraries to .netstandard 2.1 but maintains .netstandard 2.0 for those using this library with .netcoreapp 2.1

this will also rev the version from 1.0.1 to 1.0.2 to indicate a patch increment (even though the framework was updated) as the package is still backwards compatible and no new features have been added