### PR TITLE
Improved API consistency for response parsing

### DIFF
--- a/Src/Fido2/AuthenticatorAssertionResponse.cs
+++ b/Src/Fido2/AuthenticatorAssertionResponse.cs
@@ -18,13 +18,11 @@ namespace Fido2NetLib
         }
 
         public AuthenticatorAssertionRawResponse Raw { get; set; }
-
         public byte[] AuthenticatorData { get; set; }
         public byte[] Signature { get; set; }
         public byte[] UserHandle { get; set; }
-        public object CredentialId { get; private set; }
 
-        internal static AuthenticatorAssertionResponse Parse(AuthenticatorAssertionRawResponse rawResponse)
+        public static AuthenticatorAssertionResponse Parse(AuthenticatorAssertionRawResponse rawResponse)
         {
             var response = new AuthenticatorAssertionResponse(rawResponse.Response.ClientDataJson)
             {


### PR DESCRIPTION
Change: expose authenticator assertion response parse method to allow direct usage. Also removed unused credential id property.

Thank you for sharing this implementation! 

From API design perspective there is a bit of room for improvement. In my specific case I can't comfortable use the Fido2 class since it relies on a Fido2Configuration (which I need to generate per request due to the multi-tenant nature of my app) and it also generates a challenge which we want to handle our self (funny comment in code: // note: I have no idea if this crypto is ok...). For authenticator registration it worked fine to by-pass the Fido2 class but not for authentication due to the internal Parse method modified in this request. 

I took the opportunity to remove the confusing CredentialId property. Theoretically that could be a breaking change. 