### PR TITLE
Bug fix: require_resident_key

### DIFF
--- a/Demo/wwwroot/js/passwordless.register.js
+++ b/Demo/wwwroot/js/passwordless.register.js
@@ -15,7 +15,7 @@ async function handleRegisterSubmit(event) {
     let user_verification = "preferred";
 
     // possible values: true,false
-    let require_resident_key = false;
+    let require_resident_key = "false";
 
 
 

--- a/Demo/wwwroot/js/usernameless.register.js
+++ b/Demo/wwwroot/js/usernameless.register.js
@@ -16,7 +16,7 @@ async function handleRegisterSubmit(event) {
 
     // possible values: true,false
     // NOTE: For usernameless scenarios, resident key must be set to true.
-    let require_resident_key = true;
+    let require_resident_key = "true";
 
 
 


### PR DESCRIPTION
The `require_resident_key` property does not work properly unless it is a string.  This PR fixes that bug.  Tested with Chrome on Windows 10.