### PR TITLE
TPM and Packed attestation not validating root certs

### DIFF
--- a/Src/Fido2/AttestationFormat/Packed.cs
+++ b/Src/Fido2/AttestationFormat/Packed.cs
@@ -140,7 +140,13 @@ namespace Fido2NetLib.AttestationFormat
                             chain.ChainPolicy.ExtraStore.Add(cert);
                         }
                     }
+
                     var valid = chain.Build(trustPath[0]);
+
+                    // because we are using AllowUnknownCertificateAuthority we have to verify that the root matches ourselves
+                    var chainRoot = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
+                    valid = valid && chainRoot.RawData.SequenceEqual(root.RawData);
+
                     if (false == valid)
                     {
                         throw new Fido2VerificationException("Invalid certificate chain in packed attestation");

--- a/Src/Fido2/AttestationFormat/Tpm.cs
+++ b/Src/Fido2/AttestationFormat/Tpm.cs
@@ -573,6 +573,10 @@ namespace Fido2NetLib.AttestationFormat
                         }
                     }
                     valid = chain.Build(new X509Certificate2(X5c.Values.First().GetByteString()));
+
+                    // because we are using AllowUnknownCertificateAuthority we have to verify that the root matches ourselves
+                    var chainRoot = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
+                    valid = valid && chainRoot.RawData.SequenceEqual(tpmRoots[i].RawData);
                 }
                 if (false == valid)
                     throw new Fido2VerificationException("TPM attestation failed chain validation");

--- a/Src/Fido2/AttestationFormat/Tpm.cs
+++ b/Src/Fido2/AttestationFormat/Tpm.cs
@@ -555,7 +555,7 @@ namespace Fido2NetLib.AttestationFormat
                 {
                     var chain = new X509Chain();
                     chain.ChainPolicy.ExtraStore.Add(tpmRoots[i]);
-                    i++;
+                    
                     chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                     if (tpmManufacturer == "id:FFFFF1D0")
                     {
@@ -577,6 +577,7 @@ namespace Fido2NetLib.AttestationFormat
                     // because we are using AllowUnknownCertificateAuthority we have to verify that the root matches ourselves
                     var chainRoot = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
                     valid = valid && chainRoot.RawData.SequenceEqual(tpmRoots[i].RawData);
+                    i++;
                 }
                 if (false == valid)
                     throw new Fido2VerificationException("TPM attestation failed chain validation");


### PR DESCRIPTION
I was quite confused when my Solo Hacker key was passing attestation -- even with modified firmware. The root is not in the metadata repository (hacker has a different root than secure) and it didn't matter.  It seems there was a misconception with what  `X509VerificationFlags.AllowUnknownCertificateAuthority` actually does. https://github.com/dotnet/runtime/issues/26449

This request adds a check to ensure that the root of the chain building matches the expected root from metadata. 