### PR TITLE
Add optional validation of attestation root certs

### DIFF
--- a/Demo/Startup.cs
+++ b/Demo/Startup.cs
@@ -49,6 +49,7 @@ namespace Fido2Demo
                 options.TimestampDriftTolerance = Configuration.GetValue<int>("fido2:timestampDriftTolerance");
                 options.MDSAccessKey = Configuration["fido2:MDSAccessKey"];
                 options.MDSCacheDirPath = Configuration["fido2:MDSCacheDirPath"];
+                options.RequireValidAttestationRoot = Configuration.GetValue<bool>("fido2:requireValidAttestationRoot");
             })
             .AddCachedMetadataService(config =>
             {
@@ -60,22 +61,7 @@ namespace Fido2Demo
                 }
             });
 
-            services.AddFido2(options =>
-            {
-                options.ServerDomain = Configuration["fido2:serverDomain"];
-                options.ServerName = "FIDO2 Test";
-                options.Origin = Configuration["fido2:origin"];
-                options.TimestampDriftTolerance = Configuration.GetValue<int>("fido2:timestampDriftTolerance");
-            })
-            .AddCachedMetadataService(config =>
-            {
-                //They'll be used in a "first match wins" way in the order registered
-                config.AddStaticMetadataRepository();
-                if (!string.IsNullOrWhiteSpace(Configuration["fido2:MDSAccessKey"]))
-                {
-                    config.AddFidoMetadataRepository(Configuration["fido2:MDSAccessKey"]);
-                }
-            });
+        
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Demo/appsettings.json
+++ b/Demo/appsettings.json
@@ -3,7 +3,8 @@
     "serverDomain": "localhost",
     "origin": "https://localhost:44329",
     "timestampDriftTolerance": 300000,
-    "MDSAccessKey": null
+    "MDSAccessKey": null,
+    "requireValidAttestationRoot":  false
   },  
   "Logging": {
     "IncludeScopes": false,

--- a/Src/Fido2.Models/Fido2Configuration.cs
+++ b/Src/Fido2.Models/Fido2Configuration.cs
@@ -16,6 +16,11 @@ namespace Fido2NetLib
         public int TimestampDriftTolerance { get; set; } = 0; //Pretty sure 0 will never work - need a better default?
 
         /// <summary>
+        /// When checking attestation, require the attestation to chain to a known root
+        /// </summary>
+        public bool RequireValidAttestationRoot { get; set; } = false;
+
+        /// <summary>
         /// The size of the challenges sent to the client
         /// </summary>
         public int ChallengeSize { get; set; } = 16;

--- a/Src/Fido2/AuthenticatorAttestationResponse.cs
+++ b/Src/Fido2/AuthenticatorAttestationResponse.cs
@@ -135,7 +135,7 @@ namespace Fido2NetLib
 
                 case "tpm":
                     // https://www.w3.org/TR/webauthn/#tpm-attestation
-                    verifier = new Tpm(AttestationObject.AttStmt, AttestationObject.AuthData, clientDataHash);
+                    verifier = new Tpm(AttestationObject.AttStmt, AttestationObject.AuthData, clientDataHash, config.RequireValidAttestationRoot);
                     break;
 
                 case "android-key":
@@ -150,12 +150,12 @@ namespace Fido2NetLib
 
                 case "fido-u2f":
                     // https://www.w3.org/TR/webauthn/#fido-u2f-attestation
-                    verifier = new FidoU2f(AttestationObject.AttStmt, AttestationObject.AuthData, clientDataHash, metadataService);
+                    verifier = new FidoU2f(AttestationObject.AttStmt, AttestationObject.AuthData, clientDataHash, metadataService, config.RequireValidAttestationRoot);
                     break;
 
                 case "packed":
                     // https://www.w3.org/TR/webauthn/#packed-attestation
-                    verifier = new Packed(AttestationObject.AttStmt, AttestationObject.AuthData, clientDataHash, metadataService);
+                    verifier = new Packed(AttestationObject.AttStmt, AttestationObject.AuthData, clientDataHash, metadataService, config.RequireValidAttestationRoot);
                     break;
 
                 default: throw new Fido2VerificationException("Missing or unknown attestation type");


### PR DESCRIPTION
As discussed in #159 and #158, this adds a configurable flag to validate that the root certificate matches a known root. This applies to TPM, Packed and U2F attestation formats.

To be honest, I think this should always be on, particularly for Packed and U2F. The code really seems to imply that the validation has occurred as this is implemented within the metadata verification. TPM is more tricky since the attestation root situation sucks for TPM. I'll submit a separate PR to hopefully improve that.