### PR TITLE
Fix SafetyNet attestation verification, add unit tests

### DIFF
--- a/Demo/Startup.cs
+++ b/Demo/Startup.cs
@@ -38,7 +38,7 @@ namespace Fido2Demo
                 // Strict SameSite mode is required because the default mode used
                 // by ASP.NET Core 3 isn't understood by the Conformance Tool
                 // and breaks conformance testing
-                options.Cookie.SameSite = SameSiteMode.Strict;
+                options.Cookie.SameSite = SameSiteMode.Unspecified;
             });
 
             services.AddFido2(options =>

--- a/Src/Fido2/AttestationFormat/AndroidSafetyNet.cs
+++ b/Src/Fido2/AttestationFormat/AndroidSafetyNet.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -20,6 +22,19 @@ namespace Fido2NetLib.AttestationFormat
             _driftTolerance = driftTolerance;
         }
 
+        private X509Certificate2 GetX509Certificate(string certString)
+        {
+            try
+            {
+                var certBytes = Convert.FromBase64String(certString);
+                return new X509Certificate2(certBytes);
+            }
+            catch (Exception ex)
+            {
+                throw new ArgumentException("Could not parse X509 certificate.", ex);
+            }
+        }
+
         public override void Verify()
         {
             // Verify that attStmt is valid CBOR conforming to the syntax defined above and perform 
@@ -36,15 +51,45 @@ namespace Fido2NetLib.AttestationFormat
                 throw new Fido2VerificationException("Invalid response in SafetyNet data");
 
             var response = attStmt["response"].GetByteString();
-            var signedAttestationStatement = Encoding.UTF8.GetString(response);
-            var jwtToken = new JwtSecurityToken(signedAttestationStatement);
-            X509SecurityKey[] keys = (jwtToken.Header["x5c"] as JArray)
-                .Values<string>()
-                .Select(x => new X509SecurityKey(
-                    new X509Certificate2(Convert.FromBase64String(x))))
-                .ToArray();
-            if ((null == keys) || (0 == keys.Count()))
-                throw new Fido2VerificationException("SafetyNet attestation missing x5c");
+            var responseJWT = Encoding.UTF8.GetString(response);
+
+            if (string.IsNullOrWhiteSpace(responseJWT))
+                throw new Fido2VerificationException("SafetyNet response null or whitespace");
+
+            var jwtParts = responseJWT.Split('.');
+
+            if (jwtParts.Length != 3)
+                throw new Fido2VerificationException("SafetyNet response JWT does not have the 3 expected components");
+
+            var jwtHeaderString = jwtParts.First();
+            var jwtHeaderJSON = JObject.Parse(Encoding.UTF8.GetString(Base64Url.Decode(jwtHeaderString)));
+
+            var x5cArray = jwtHeaderJSON["x5c"] as JArray;
+
+            if (x5cArray == null)
+                throw new Fido2VerificationException("SafetyNet response JWT header missing x5c");
+            var x5cStrings = x5cArray.Values<string>().ToList();
+
+            if (x5cStrings.Count == 0)
+                throw new Fido2VerificationException("No keys were present in the TOC header in SafetyNet response JWT");
+
+            var certs = new List<X509Certificate2>();
+            var keys = new List<SecurityKey>();
+
+            foreach (var certString in x5cStrings)
+            {
+                var cert = GetX509Certificate(certString);
+                certs.Add(cert);
+
+                var ecdsaPublicKey = cert.GetECDsaPublicKey();
+                if (ecdsaPublicKey != null)
+                    keys.Add(new ECDsaSecurityKey(ecdsaPublicKey));
+
+                var rsaPublicKey = cert.GetRSAPublicKey();
+                if (rsaPublicKey != null)
+                    keys.Add(new RsaSecurityKey(rsaPublicKey));
+            }
+
             var validationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = false,
@@ -55,57 +100,84 @@ namespace Fido2NetLib.AttestationFormat
             };
 
             var tokenHandler = new JwtSecurityTokenHandler();
-
-            tokenHandler.ValidateToken(
-                signedAttestationStatement,
-                validationParameters,
-                out var validatedToken);
-
-            if (false == (validatedToken.SigningKey is X509SecurityKey))
-                throw new Fido2VerificationException("Safetynet signing key invalid");
+            SecurityToken validatedToken = null;
+            try
+            { 
+                tokenHandler.ValidateToken(
+                    responseJWT,
+                    validationParameters,
+                    out validatedToken);
+            }
+            catch (SecurityTokenException ex)
+            {
+                throw new Fido2VerificationException("SafetyNet response security token validation failed", ex);
+            }
 
             var nonce = "";
-            var payload = false;
+            bool? ctsProfileMatch = null;
+            var timestampMs = DateTimeHelper.UnixEpoch;
+
+            var jwtToken = validatedToken as JwtSecurityToken;
+
             foreach (var claim in jwtToken.Claims)
             {
                 if (("nonce" == claim.Type) && ("http://www.w3.org/2001/XMLSchema#string" == claim.ValueType) && (0 != claim.Value.Length))
                     nonce = claim.Value;
                 if (("ctsProfileMatch" == claim.Type) && ("http://www.w3.org/2001/XMLSchema#boolean" == claim.ValueType))
                 {
-                    payload = bool.Parse(claim.Value);
+                    ctsProfileMatch = bool.Parse(claim.Value);
                 }
                 if (("timestampMs" == claim.Type) && ("http://www.w3.org/2001/XMLSchema#integer64" == claim.ValueType))
                 {
-                    var dt = DateTimeHelper.UnixEpoch.AddMilliseconds(double.Parse(claim.Value));
-                    var notAfter = DateTime.UtcNow.AddMilliseconds(_driftTolerance);
-                    var notBefore = DateTime.UtcNow.AddMinutes(-1).AddMilliseconds(-(_driftTolerance));
-                    if ((notAfter < dt) || ((notBefore) > dt))
-                    {
-                        throw new Fido2VerificationException("Android SafetyNet timestampMs must be between one minute ago and now");
-                    }
+                    timestampMs = DateTimeHelper.UnixEpoch.AddMilliseconds(double.Parse(claim.Value));
                 }
+            }
+
+            var notAfter = DateTime.UtcNow.AddMilliseconds(_driftTolerance);
+            var notBefore = DateTime.UtcNow.AddMinutes(-1).AddMilliseconds(-(_driftTolerance));
+            if ((notAfter < timestampMs) || ((notBefore) > timestampMs))
+            {
+                throw new Fido2VerificationException(string.Format("SafetyNet timestampMs must be present and between one minute ago and now, got: {0}", timestampMs.ToString()));
             }
 
             // Verify that the nonce in the response is identical to the SHA-256 hash of the concatenation of authenticatorData and clientDataHash
             if ("" == nonce)
-                throw new Fido2VerificationException("Nonce value not found in Android SafetyNet attestation");
-            using(var hasher = CryptoUtils.GetHasher(HashAlgorithmName.SHA256))
+                throw new Fido2VerificationException("Nonce value not found in SafetyNet attestation");
+
+            byte[] nonceHash = null;
+            try
+            {
+                nonceHash = Convert.FromBase64String(nonce);
+            }
+            catch (Exception ex)
+            {
+                throw new Fido2VerificationException("Nonce value not base64string in SafetyNet attestation", ex);
+            }
+
+            using (var hasher = CryptoUtils.GetHasher(HashAlgorithmName.SHA256))
             {
                 var dataHash = hasher.ComputeHash(Data);
-                var nonceHash = Convert.FromBase64String(nonce);
                 if (false == dataHash.SequenceEqual(nonceHash))
-                    throw new Fido2VerificationException("Android SafetyNet hash value mismatch");
+                    throw new Fido2VerificationException(
+                        string.Format(
+                            "SafetyNet response nonce / hash value mismatch, nonce {0}, hash {1}", 
+                            BitConverter.ToString(nonceHash).Replace("-", ""), 
+                            BitConverter.ToString(dataHash).Replace("-", "")
+                            )
+                        );
             }
 
             // Verify that the attestation certificate is issued to the hostname "attest.android.com"
-            var attCert = (validatedToken.SigningKey as X509SecurityKey).Certificate;
-            var subject = attCert.GetNameInfo(X509NameType.DnsName, false);
+            var subject = certs[0].GetNameInfo(X509NameType.DnsName, false);
             if (false == ("attest.android.com").Equals(subject))
-                throw new Fido2VerificationException("Safetynet DnsName is not attest.android.com");
+                throw new Fido2VerificationException(string.Format("SafetyNet attestation cert DnsName invalid, want {0}, got {1}", "attest.android.com", subject));
+
+            if (null == ctsProfileMatch)
+                throw new Fido2VerificationException("SafetyNet response ctsProfileMatch missing");
 
             // Verify that the ctsProfileMatch attribute in the payload of response is true
-            if (true != payload)
-                throw new Fido2VerificationException("Android SafetyNet ctsProfileMatch must be true");
+            if (true != ctsProfileMatch)
+                throw new Fido2VerificationException("SafetyNet response ctsProfileMatch false");
         }
     }
 }

--- a/Test/Attestation/AndroidSafetyNet.cs
+++ b/Test/Attestation/AndroidSafetyNet.cs
@@ -1,16 +1,1046 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using fido2_net_lib.Test;
+using Fido2NetLib;
+using Fido2NetLib.Objects;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using PeterO.Cbor;
+using Xunit;
 
 namespace Test.Attestation
 {
-    class AndroidSafetyNet : Fido2Tests.Attestation
+    public class AndroidSafetyNet : Fido2Tests.Attestation
     {
         public AndroidSafetyNet()
         {
             _attestationObject = CBORObject.NewMap().Add("fmt", "android-safetynet");
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
+                        new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    { 
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Add("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+        }
+        
+        [Fact]
+        public async void TestAndroidSafetyNet()
+        {
+            var res = await MakeAttestationResponse();
+            Assert.Equal(string.Empty, res.ErrorMessage);
+            Assert.Equal("ok", res.Status);
+            Assert.Equal(_aaguid, res.Result.Aaguid);
+            Assert.Equal(_signCount, res.Result.Counter);
+            Assert.Equal("android-safetynet", res.Result.CredType);
+            Assert.Equal(_credentialID, res.Result.CredentialId);
+            Assert.Null(res.Result.ErrorMessage);
+            Assert.Equal(_credentialPublicKey.GetBytes(), res.Result.PublicKey);
+            Assert.Null(res.Result.Status);
+            Assert.Equal("Test User", res.Result.User.DisplayName);
+            Assert.Equal(Encoding.UTF8.GetBytes("testuser"), res.Result.User.Id);
+            Assert.Equal("testuser", res.Result.User.Name);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetVerNotString()
+        {
+            _attestationObject["attStmt"].Set("ver", 1);
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("Invalid version in SafetyNet data", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetVerMissing()
+        {
+            _attestationObject["attStmt"].Set("ver", null);
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("Invalid version in SafetyNet data", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetVerStrLenZero()
+        {
+            _attestationObject["attStmt"].Set("ver", "");
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("Invalid version in SafetyNet data", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseMissing()
+        {
+            _attestationObject["attStmt"].Set("response", null);
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("Invalid response in SafetyNet data", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseNotByteString()
+        {
+            _attestationObject["attStmt"].Set("response", "telephone");
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("Invalid response in SafetyNet data", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseByteStringLenZero()
+        {
+            _attestationObject["attStmt"].Set("response", new byte[] { });
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("Invalid response in SafetyNet data", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyResponseWhitespace()
+        {
+            _attestationObject["attStmt"].Set("response", Encoding.UTF8.GetBytes(" "));
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("SafetyNet response null or whitespace", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetMalformedResponseJWT()
+        {
+            var response = _attestationObject["attStmt"]["response"].GetByteString();
+            var responseJWT = Encoding.UTF8.GetString(response);
+            var jwtParts = responseJWT.Split('.');
+            _attestationObject["attStmt"].Set("response", Encoding.UTF8.GetBytes(jwtParts.First()));
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("SafetyNet response JWT does not have the 3 expected components", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseJWTMissingX5c()
+        {
+            var response = _attestationObject["attStmt"]["response"].GetByteString();
+            var jwtParts = Encoding.UTF8.GetString(response).Split('.');
+            var jwtHeaderJSON = JObject.Parse(Encoding.UTF8.GetString(Base64Url.Decode(jwtParts.First())));
+            jwtHeaderJSON.Remove("x5c");
+            jwtParts[0] = Base64Url.Encode(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(jwtHeaderJSON)));
+            response = Encoding.UTF8.GetBytes(string.Join(".", jwtParts));
+            _attestationObject["attStmt"].Set("response", response);
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("SafetyNet response JWT header missing x5c", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseJWTX5cNoKeys()
+        {
+            var response = _attestationObject["attStmt"]["response"].GetByteString();
+            var jwtParts = Encoding.UTF8.GetString(response).Split('.');
+            var jwtHeaderJSON = JObject.Parse(Encoding.UTF8.GetString(Base64Url.Decode(jwtParts.First())));
+            jwtHeaderJSON.Remove("x5c");
+            jwtHeaderJSON.Add("x5c", JToken.FromObject(new List<string> {  }));
+            jwtParts[0] = Base64Url.Encode(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(jwtHeaderJSON)));
+            response = Encoding.UTF8.GetBytes(string.Join(".", jwtParts));
+            _attestationObject["attStmt"].Set("response", response);
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("No keys were present in the TOC header in SafetyNet response JWT", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetJwtInvalid()
+        {
+            var response = _attestationObject["attStmt"]["response"].GetByteString();
+            var jwtParts = Encoding.UTF8.GetString(response).Split('.');
+            var jwtHeaderJSON = JObject.Parse(Encoding.UTF8.GetString(Base64Url.Decode(jwtParts.First())));
+            jwtHeaderJSON.Remove("x5c");
+            byte[] x5c = null;
+            using (var ecdsaAtt = ECDsa.Create())
+            {
+                var attRequest = new CertificateRequest(new X500DistinguishedName("CN=fakeattest.android.com"), ecdsaAtt, HashAlgorithmName.SHA256);
+
+                byte[] serial = new byte[12];
+
+                using (var rng = RandomNumberGenerator.Create())
+                {
+                    rng.GetBytes(serial);
+                }
+                using (X509Certificate2 publicOnly = attRequest.CreateSelfSigned(
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow.AddDays(2)))
+                {
+                    x5c = publicOnly.RawData;
+                }
+            }
+
+            jwtHeaderJSON.Add("x5c", JToken.FromObject(new List<string> { Convert.ToBase64String(x5c) }));
+            jwtParts[0] = Base64Url.Encode(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(jwtHeaderJSON)));
+            response = Encoding.UTF8.GetBytes(string.Join(".", jwtParts));
+            _attestationObject["attStmt"].Set("response", response);
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.StartsWith("SafetyNet response security token validation failed", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseClaimTimestampExpired()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
+                        new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.AddDays(-1).ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.StartsWith("SafetyNet timestampMs must be present and between one minute ago and now, got:", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseClaimTimestampNotYetValid()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
+                        new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.StartsWith("SafetyNet timestampMs must be present and between one minute ago and now, got:", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseClaimTimestampMissing()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
+                        new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.StartsWith("SafetyNet timestampMs must be present and between one minute ago and now, got:", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseClaimNonceMissing()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("Nonce value not found in SafetyNet attestation", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseClaimNonceInvalid()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+                    attToBeSigned[attToBeSigned.Length - 1] ^= 0xff;
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
+                        new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.StartsWith("SafetyNet response nonce / hash value mismatch", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetResponseClaimNonceNotBase64String()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", "n0tbase_64/str!ng" , ClaimValueTypes.String),
+                        new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("Nonce value not base64string in SafetyNet attestation", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetAttestationCertSubjectInvalid()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=sunshine.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
+                        new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.StartsWith("SafetyNet attestation cert DnsName invalid", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetCtsProfileMatchMissing()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("SafetyNet response ctsProfileMatch missing", ex.Result.Message);
+        }
+
+        [Fact]
+        public void TestAndroidSafetyNetCtsProfileMatchFalse()
+        {
+            var param = Fido2Tests._validCOSEParameters[0];
+            X509Certificate2 root, attestnCert;
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow;
+            DateTimeOffset notAfter = notBefore.AddDays(2);
+            var attDN = new X500DistinguishedName("CN=attest.android.com, OU=SafetyNet Authenticator Attestation, O=FIDO2-NET-LIB, C=US");
+
+            using (var ecdsaRoot = ECDsa.Create())
+            {
+                var rootRequest = new CertificateRequest(rootDN, ecdsaRoot, HashAlgorithmName.SHA256);
+                rootRequest.CertificateExtensions.Add(caExt);
+
+                var curve = (COSE.EllipticCurve)param[2];
+                ECCurve eCCurve = ECCurve.NamedCurves.nistP256;
+                using (root = rootRequest.CreateSelfSigned(
+                    notBefore,
+                    notAfter))
+
+                using (var ecdsaAtt = ECDsa.Create(eCCurve))
+                {
+                    var attRequest = new CertificateRequest(attDN, ecdsaAtt, HashAlgorithmName.SHA256);
+
+                    byte[] serial = new byte[12];
+
+                    using (var rng = RandomNumberGenerator.Create())
+                    {
+                        rng.GetBytes(serial);
+                    }
+                    using (X509Certificate2 publicOnly = attRequest.Create(
+                        root,
+                        notBefore,
+                        notAfter,
+                        serial))
+                    {
+                        attestnCert = publicOnly.CopyWithPrivateKey(ecdsaAtt);
+                    }
+
+                    var ecparams = ecdsaAtt.ExportParameters(true);
+
+                    var cpk = CBORObject.NewMap();
+                    cpk.Add(COSE.KeyCommonParameter.KeyType, (COSE.KeyType)param[0]);
+                    cpk.Add(COSE.KeyCommonParameter.Alg, (COSE.Algorithm)param[1]);
+                    cpk.Add(COSE.KeyTypeParameter.X, ecparams.Q.X);
+                    cpk.Add(COSE.KeyTypeParameter.Y, ecparams.Q.Y);
+                    cpk.Add(COSE.KeyTypeParameter.Crv, (COSE.EllipticCurve)param[2]);
+
+                    var x = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.X)].GetByteString();
+                    var y = cpk[CBORObject.FromObject(COSE.KeyTypeParameter.Y)].GetByteString();
+
+                    _credentialPublicKey = new CredentialPublicKey(cpk);
+
+                    var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
+
+                    List<Claim> claims = new List<Claim>
+                    {
+                        new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
+                        new Claim("ctsProfileMatch", bool.FalseString, ClaimValueTypes.Boolean),
+                        new Claim("timestampMs", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(), ClaimValueTypes.Integer64)
+                    };
+
+                    var tokenHandler = new JwtSecurityTokenHandler();
+
+                    var tokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(claims),
+                        SigningCredentials = new SigningCredentials(new ECDsaSecurityKey(ecdsaAtt), SecurityAlgorithms.EcdsaSha256Signature)
+                    };
+
+                    JwtSecurityToken securityToken = (JwtSecurityToken)tokenHandler.CreateToken(tokenDescriptor);
+                    securityToken.Header.Add(JwtHeaderParameterNames.X5c, new[] { attestnCert.RawData, root.RawData });
+
+                    string strToken = "";
+                    if (tokenHandler.CanWriteToken)
+                    {
+                        strToken = new JwtSecurityTokenHandler().WriteToken(securityToken);
+                    }
+
+                    _attestationObject.Set("attStmt", CBORObject.NewMap()
+                        .Add("ver", "F1D0")
+                        .Add("response", Encoding.UTF8.GetBytes(strToken)));
+                }
+            }
+            var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
+            Assert.Equal("SafetyNet response ctsProfileMatch false", ex.Result.Message);
         }
     }
 }

--- a/Test/Attestation/Tpm.cs
+++ b/Test/Attestation/Tpm.cs
@@ -174,19 +174,16 @@ namespace Test.Attestation
                                     kdf?.ToArray(), // KDF
                                     unique.ToArray() // Unique
                                 );
-
-                                byte[] data = new byte[_authData.Length + _clientDataHash.Length];
-                                Buffer.BlockCopy(_authData, 0, data, 0, _authData.Length);
-                                Buffer.BlockCopy(_clientDataHash, 0, data, _authData.Length, _clientDataHash.Length);
-
-                                byte[] hashedData;
-                                byte[] hashedPubArea;
+                                
                                 var hashAlg = CryptoUtils.algMap[(int)alg];
-                                using (var hasher = CryptoUtils.GetHasher(CryptoUtils.algMap[(int)alg]))
+                                byte[] hashedData = _attToBeSignedHash(hashAlg);
+                                
+                                byte[] hashedPubArea;
+                                using (var hasher = CryptoUtils.GetHasher(hashAlg))
                                 {
-                                    hashedData = hasher.ComputeHash(data);
                                     hashedPubArea = hasher.ComputeHash(pubArea);
                                 }
+
                                 IEnumerable<byte> extraData = BitConverter
                                     .GetBytes((UInt16)hashedData.Length)
                                     .Reverse()

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -134,7 +134,7 @@ namespace fido2_net_lib.Test
                 }
             }
 
-            public byte[] _data
+            public byte[] _attToBeSigned
             {
                 get
                 {
@@ -144,6 +144,15 @@ namespace fido2_net_lib.Test
                     return data;
                 }
             }
+
+            public byte[] _attToBeSignedHash(HashAlgorithmName alg)
+            {
+                using (var hasher = CryptoUtils.GetHasher(alg))
+                {
+                    return hasher.ComputeHash(_attToBeSigned);
+                }
+            }
+
             public byte[] _credentialID;
             public const AuthenticatorFlags _flags = AuthenticatorFlags.AT | AuthenticatorFlags.ED | AuthenticatorFlags.UP | AuthenticatorFlags.UV;
             public ushort _signCount;
@@ -290,7 +299,7 @@ namespace fido2_net_lib.Test
                         {
                             var ecparams = ecdsa.ExportParameters(true);
                             _credentialPublicKey = MakeCredentialPublicKey(kty, alg, curve, ecparams.Q.X, ecparams.Q.Y);
-                            var signature = ecdsa.SignData(_data, CryptoUtils.algMap[(int)alg]);
+                            var signature = ecdsa.SignData(_attToBeSigned, CryptoUtils.algMap[(int)alg]);
                             return EcDsaSigFromSig(signature, ecdsa.KeySize);
                         }
                     case COSE.KeyType.RSA:
@@ -316,12 +325,12 @@ namespace fido2_net_lib.Test
 
                             var rsaparams = rsa.ExportParameters(true);
                             _credentialPublicKey = MakeCredentialPublicKey(kty, alg, rsaparams.Modulus, rsaparams.Exponent);
-                            return rsa.SignData(_data, CryptoUtils.algMap[(int)alg], padding);
+                            return rsa.SignData(_attToBeSigned, CryptoUtils.algMap[(int)alg], padding);
                         }
                     case COSE.KeyType.OKP:
                         {
                             _credentialPublicKey = MakeCredentialPublicKey(kty, alg, COSE.EllipticCurve.Ed25519, publicKey);
-                            return Ed25519.Sign(_data, expandedPrivateKey);
+                            return Ed25519.Sign(_attToBeSigned, expandedPrivateKey);
                         }
 
                     default:


### PR DESCRIPTION
- Related to #153, SafetyNet attestation verification broke when System.IdentityModel.Tokens.Jwt was updated.  Fixed in similar fashion.

- Refactor SafetyNet attestation verification

- Add SafetyNet attestation verification unit tests

- All 172 conformance tests pass with conformance tool version 1.3.4.