### PR TITLE
Compare certificate validity period correctly when the machine is using a time zone other than UTC

### DIFF
--- a/Src/Fido2/AttestationFormat/Packed.cs
+++ b/Src/Fido2/AttestationFormat/Packed.cs
@@ -74,7 +74,9 @@ namespace Fido2NetLib.AttestationFormat
 
                     var x5ccert = new X509Certificate2(enumerator.Current.GetByteString());
 
-                    if (DateTime.UtcNow < x5ccert.NotBefore || DateTime.UtcNow > x5ccert.NotAfter)
+                    // X509Certificate2.NotBefore/.NotAfter return LOCAL DateTimes, so
+                    // it's correct to compare using DateTime.Now.
+                    if (DateTime.Now < x5ccert.NotBefore || DateTime.Now > x5ccert.NotAfter)
                         throw new Fido2VerificationException("Packed signing certificate expired or not yet valid");
                 }
 


### PR DESCRIPTION
When comparing two DateTimes, the `Kind` attribute is ignored, so comparing an UTC DateTime and a local DateTime do not give the expected result.

While the validity period is encoded as UTC in the certificate itself, it is converted to local time before it is returned in the X509Certificate2.NotBefore / X509Certificate.NotAfter attributes. This means that if we want to check whether the certificate is currently valid, we should compare it with the current _local_ time.

Fixes: #185 