### PR TITLE
Fixed SANFromAttnCertExts to correctly extract the TPM properties from the Subject Alternative Name certificate extension

### DIFF
--- a/Src/Fido2/AttestationFormat/Tpm.cs
+++ b/Src/Fido2/AttestationFormat/Tpm.cs
@@ -290,15 +290,15 @@ namespace Fido2NetLib.AttestationFormat
                             propertySequence.CheckTag(AsnElt.SEQUENCE);
                             propertySequence.CheckNumSub(2);
 
-                            var properyOid = propertySequence.GetSub(0);
-                            properyOid.CheckTag(AsnElt.OBJECT_IDENTIFIER);
-                            properyOid.CheckPrimitive();
+                            var propertyOid = propertySequence.GetSub(0);
+                            propertyOid.CheckTag(AsnElt.OBJECT_IDENTIFIER);
+                            propertyOid.CheckPrimitive();
 
                             var propertyValue = propertySequence.GetSub(1);
                             propertyValue.CheckTag(AsnElt.UTF8String);
                             propertyValue.CheckPrimitive();
 
-                            switch (properyOid.GetOID())
+                            switch (propertyOid.GetOID())
                             {
                                 case ("2.23.133.2.1"):
                                     tpmManufacturer = propertyValue.GetString();


### PR DESCRIPTION
As mentioned in https://github.com/abergs/fido2-net-lib/pull/175 this is a fix for the issue discovered when trying to register a TPM-equipped Windows 10 laptop with Windows Hello.

In summary the existing logic assumed the data shown in example A.1 on page 35 of this document: https://trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf was one level down from where it is (directoryElement).

The fix removes the "directoryName" element and does some light refactoring for readability. 

Tested on Windows 10 with Chrome 85 and an ST Microelectronic TPM in a Dell Latitude 5401
