### PR TITLE
MDS error handling and cache-friendlieness refactoring

### DIFF
--- a/Demo/Startup.cs
+++ b/Demo/Startup.cs
@@ -53,11 +53,12 @@ namespace Fido2Demo
             .AddCachedMetadataService(config =>
             {
                 //They'll be used in a "first match wins" way in the order registered
-                config.AddStaticMetadataRepository();
+                
                 if (!string.IsNullOrWhiteSpace(Configuration["fido2:MDSAccessKey"]))
                 {
                     config.AddFidoMetadataRepository(Configuration["fido2:MDSAccessKey"]);
                 }
+                config.AddStaticMetadataRepository();
             });
 
         

--- a/Src/Fido2.Models/Metadata/MetadataTOCPayload.cs
+++ b/Src/Fido2.Models/Metadata/MetadataTOCPayload.cs
@@ -18,7 +18,7 @@ namespace Fido2NetLib
         /// </remarks>
         [JsonProperty("legalHeader")]
         public string LegalHeader { get; set; }
-        /// <summary>
+        /// <summary>   
         /// Gets or sets the serial number of this UAF Metadata TOC Payload. 
         /// </summary>
         /// <remarks>
@@ -36,5 +36,11 @@ namespace Fido2NetLib
         /// </summary>
         [JsonProperty("entries", Required = Required.Always)]
         public MetadataTOCPayloadEntry[] Entries { get; set; }
+
+        /// <summary>
+        /// The "alg" property from the original JWT header. Used to validate MetadataStatements.
+        /// </summary>
+        [JsonProperty("jwtAlg", Required = Required.AllowNull)]
+        public string JwtAlg { get; set; }
     }
 }

--- a/Src/Fido2/IMetadataRepository.cs
+++ b/Src/Fido2/IMetadataRepository.cs
@@ -7,6 +7,6 @@ namespace Fido2NetLib
     {
         Task<MetadataTOCPayload> GetToc();
 
-        Task<MetadataStatement> GetMetadataStatement(MetadataTOCPayloadEntry entry);
+        Task<MetadataStatement> GetMetadataStatement(MetadataTOCPayload toc, MetadataTOCPayloadEntry entry);
     }
 }

--- a/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
+++ b/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
@@ -33,8 +33,6 @@ namespace Fido2NetLib
         protected readonly string _tocUrl;
         protected readonly HttpClient _httpClient;
 
-        protected string _tocAlg;
-
         private readonly string _origin = "http://localhost";
 
         private readonly string _getEndpointsUrl = "https://fidoalliance.co.nz/mds/getEndpoints";
@@ -45,24 +43,14 @@ namespace Fido2NetLib
             _origin = origin;
         }
 
-        private Task<string> GetTocAlg()
-        {
-            if (!string.IsNullOrEmpty(_tocAlg))
-            {
-                return Task.FromResult(_tocAlg);
-            }
-            throw new InvalidOperationException("Could not determine TOC algorith.");
-        }
-
-        public async Task<MetadataStatement> GetMetadataStatement(MetadataTOCPayloadEntry entry)
+        public async Task<MetadataStatement> GetMetadataStatement(MetadataTOCPayload toc, MetadataTOCPayloadEntry entry)
         {
             var statementBase64Url = await DownloadStringAsync(entry.Url);
-            var tocAlg = await GetTocAlg();
-
+            
             var statementBytes = Base64Url.Decode(statementBase64Url);
             var statementString = Encoding.UTF8.GetString(statementBytes, 0, statementBytes.Length);
             var statement = Newtonsoft.Json.JsonConvert.DeserializeObject<MetadataStatement>(statementString);
-            using(HashAlgorithm hasher = CryptoUtils.GetHasher(new HashAlgorithmName(tocAlg)))
+            using(HashAlgorithm hasher = CryptoUtils.GetHasher(new HashAlgorithmName(toc.JwtAlg)))
             {
                 statement.Hash = Base64Url.Encode(hasher.ComputeHash(Encoding.UTF8.GetBytes(statementBase64Url)));
             }
@@ -143,12 +131,12 @@ namespace Fido2NetLib
             }
         }
 
-        public async Task<MetadataTOCPayload> DeserializeAndValidateToc(string toc)
+        public async Task<MetadataTOCPayload> DeserializeAndValidateToc(string rawTocJwt)
         {
-            if (string.IsNullOrWhiteSpace(toc))
-                throw new ArgumentNullException(nameof(toc));
+            if (string.IsNullOrWhiteSpace(rawTocJwt))
+                throw new ArgumentNullException(nameof(rawTocJwt));
 
-            var jwtParts = toc.Split('.');
+            var jwtParts = rawTocJwt.Split('.');
 
             if (jwtParts.Length != 3)
                 throw new ArgumentException("The JWT does not have the 3 expected components");
@@ -156,9 +144,9 @@ namespace Fido2NetLib
             var tocHeader = jwtParts.First();
             var tokenHeader = JObject.Parse(System.Text.Encoding.UTF8.GetString(Base64Url.Decode(tocHeader)));
 
-            _tocAlg = tokenHeader["alg"]?.Value<string>();
+            var tocAlg = tokenHeader["alg"]?.Value<string>();
 
-            if(_tocAlg == null)
+            if(tocAlg == null)
                 throw new ArgumentNullException("No alg value was present in the TOC header.");
 
             var x5cArray = tokenHeader["x5c"] as JArray;
@@ -201,7 +189,7 @@ namespace Fido2NetLib
             var tokenHandler = new JwtSecurityTokenHandler();
 
             tokenHandler.ValidateToken(
-                toc,
+                rawTocJwt,
                 validationParameters,
                 out var validatedToken);
 
@@ -250,7 +238,10 @@ namespace Fido2NetLib
                 throw new Fido2VerificationException("Failed to validate cert chain while parsing TOC");
 
             var tocPayload = ((JwtSecurityToken)validatedToken).Payload.SerializeToJson();
-            return Newtonsoft.Json.JsonConvert.DeserializeObject<MetadataTOCPayload>(tocPayload);
+
+            var toc = Newtonsoft.Json.JsonConvert.DeserializeObject<MetadataTOCPayload>(tocPayload);
+            toc.JwtAlg = tocAlg;
+            return toc;
         }
     }
 }

--- a/Src/Fido2/Metadata/FileSystemMetadataRepository.cs
+++ b/Src/Fido2/Metadata/FileSystemMetadataRepository.cs
@@ -20,7 +20,7 @@ namespace Fido2NetLib
             _entries = new Dictionary<Guid, MetadataTOCPayloadEntry>();
         }
 
-        public async Task<MetadataStatement> GetMetadataStatement(MetadataTOCPayloadEntry entry)
+        public async Task<MetadataStatement> GetMetadataStatement(MetadataTOCPayload toc, MetadataTOCPayloadEntry entry)
         {
             if (_toc == null)
                 await GetToc();

--- a/Src/Fido2/Metadata/StaticMetadataRepository.cs
+++ b/Src/Fido2/Metadata/StaticMetadataRepository.cs
@@ -41,7 +41,7 @@ namespace Fido2NetLib
             _cacheUntil = cacheUntil;
         }
 
-        public async Task<MetadataStatement> GetMetadataStatement(MetadataTOCPayloadEntry entry)
+        public async Task<MetadataStatement> GetMetadataStatement(MetadataTOCPayload toc, MetadataTOCPayloadEntry entry)
         {
             if (_toc == null)
                 await GetToc();

--- a/Src/Fido2/SimpleMetadataService.cs
+++ b/Src/Fido2/SimpleMetadataService.cs
@@ -51,23 +51,20 @@ namespace Fido2NetLib
             }
         }
 
-        protected virtual async Task LoadEntryStatement(IMetadataRepository repository, MetadataTOCPayloadEntry entry)
+        protected virtual async Task LoadEntryStatement(IMetadataRepository repository, MetadataTOCPayload toc, MetadataTOCPayloadEntry entry)
         {
             if (entry.AaGuid != null)
             {
-                var statement = await repository.GetMetadataStatement(entry);
+                var statement = await repository.GetMetadataStatement(toc, entry);
 
                 if (!string.IsNullOrWhiteSpace(statement.AaGuid))
                 {
                     _metadataStatements.TryAdd(Guid.Parse(statement.AaGuid), statement);
-
-                    // TODO : This seems undone
-                    var statementJson = JsonConvert.SerializeObject(statement, Formatting.Indented);
                 }
             }
         }
 
-        protected virtual async Task InitializeClient(IMetadataRepository repository)
+        protected virtual async Task InitializeRepository(IMetadataRepository repository)
         {
             var toc = await repository.GetToc();
 
@@ -78,7 +75,7 @@ namespace Fido2NetLib
                     if (_entries.TryAdd(Guid.Parse(entry.AaGuid), entry))
                     {
                         //Load if it doesn't already exist
-                        await LoadEntryStatement(repository, entry);
+                        await LoadEntryStatement(repository, toc, entry);
                     }
                 }
             }
@@ -86,9 +83,9 @@ namespace Fido2NetLib
 
         public virtual async Task Initialize()
         {
-            foreach (var client in _repositories)
+            foreach (var repository in _repositories)
             {
-                await InitializeClient(client);
+                await InitializeRepository(repository);
             }
             _initialized = true;
         }

--- a/Test/MetadataServiceTests.cs
+++ b/Test/MetadataServiceTests.cs
@@ -21,7 +21,7 @@ namespace Test
 
             Assert.True(toc.Entries.Length > 0);
 
-            var entry_1 = await client.GetMetadataStatement(toc.Entries[toc.Entries.Length - 1]);
+            var entry_1 = await client.GetMetadataStatement(toc, toc.Entries[toc.Entries.Length - 1]);
 
             Assert.NotNull(entry_1.Description);
 


### PR DESCRIPTION
Improved error handling and logging for MDS errors along with a refactoring of how the TOC JWT alg is passed around to better serve the cached use-case.

The the TOC alg now gets stored in the MetadataTOCPayload class which is now passed into GetMetadataStatement. This means that it's possible to use a cached MetadataTOCPayload not created by the current IMetadataRepository instance.. 

Together these changes mean that an incident like we had with the Yubico version number won't cause the app startup to fail and will be recoverable even if the TOC is already cached.

This change will require anyone using the DistributedCacheMetadataService to clear their cache when upgrading to 2.0.