### PR TITLE
change origin verify to use fully qualified origin

### DIFF
--- a/Src/Fido2/AuthenticatorResponse.cs
+++ b/Src/Fido2/AuthenticatorResponse.cs
@@ -68,7 +68,7 @@ namespace Fido2NetLib
                 throw new Fido2VerificationException("Challenge not equal to original challenge");
 
             // 5. Verify that the value of C.origin matches the Relying Party's origin.
-            if (Origin != expectedOrigin)
+            if (!string.Equals(FullyQualifiedOrigin(this.Origin), expectedOrigin, StringComparison.OrdinalIgnoreCase))
                 throw new Fido2VerificationException($"Origin {Origin} not equal to original origin {expectedOrigin}");
 
             // 6. Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over which the assertion was obtained. 
@@ -77,6 +77,13 @@ namespace Fido2NetLib
             {
                 TokenBinding.Verify(requestTokenBindingId);
             }
+        }
+
+        private string FullyQualifiedOrigin(string origin)
+        {
+            var uri = new Uri(origin);
+
+            return $"{uri.Scheme}://{uri.Host}";
         }
     }
 }


### PR DESCRIPTION
A Huawei P40 Lite sets the origin on register or sign in to https://www.passwordless.dev/custom#heroFoot and the verification fails.

With this PR,  the fully qualified origins are compared. see also https://github.com/duo-labs/webauthn/pull/60

