### PR TITLE
Intercede FIDO md2 new TOC root cert

### DIFF
--- a/Src/Fido2.Models/Fido2MetadataException.cs
+++ b/Src/Fido2.Models/Fido2MetadataException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Fido2NetLib
+{
+    [Serializable]
+    public class Fido2MetadataException : Exception
+    {
+        public Fido2MetadataException()
+        {
+        }
+
+        public Fido2MetadataException(string message) : base(message)
+        {
+        }
+
+        public Fido2MetadataException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected Fido2MetadataException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Src/Fido2/Metadata/Fido2MetadataServiceRepository.cs
+++ b/Src/Fido2/Metadata/Fido2MetadataServiceRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
@@ -14,21 +15,26 @@ namespace Fido2NetLib
 {
     public class Fido2MetadataServiceRepository : IMetadataRepository
     {
-        //var rootFile = client.DownloadData("https://mds.fidoalliance.org/Root.cer");
-        protected const string ROOT_CERT = 
-            "MIICQzCCAcigAwIBAgIORqmxkzowRM99NQZJurcwCgYIKoZIzj0EAwMwUzELMAkG" +
-            "A1UEBhMCVVMxFjAUBgNVBAoTDUZJRE8gQWxsaWFuY2UxHTAbBgNVBAsTFE1ldGFk" +
-            "YXRhIFRPQyBTaWduaW5nMQ0wCwYDVQQDEwRSb290MB4XDTE1MDYxNzAwMDAwMFoX" +
-            "DTQ1MDYxNzAwMDAwMFowUzELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUZJRE8gQWxs" +
-            "aWFuY2UxHTAbBgNVBAsTFE1ldGFkYXRhIFRPQyBTaWduaW5nMQ0wCwYDVQQDEwRS" +
-            "b290MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFEoo+6jdxg6oUuOloqPjK/nVGyY+" +
-            "AXCFz1i5JR4OPeFJs+my143ai0p34EX4R1Xxm9xGi9n8F+RxLjLNPHtlkB3X4ims" +
-            "rfIx7QcEImx1cMTgu5zUiwxLX1ookVhIRSoso2MwYTAOBgNVHQ8BAf8EBAMCAQYw" +
-            "DwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU0qUfC6f2YshA1Ni9udeO0VS7vEYw" +
-            "HwYDVR0jBBgwFoAU0qUfC6f2YshA1Ni9udeO0VS7vEYwCgYIKoZIzj0EAwMDaQAw" +
-            "ZgIxAKulGbSFkDSZusGjbNkAhAkqTkLWo3GrN5nRBNNk2Q4BlG+AvM5q9wa5WciW" +
-            "DcMdeQIxAMOEzOFsxX9Bo0h4LOFE5y5H8bdPFYW+l5gy1tQiJv+5NUyM2IBB55XU" +
-            "YjdBz56jSA==";
+        protected const string ROOT_CERT =
+        "MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G" +
+        "A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp" +
+        "Z24xEzARBgNVBAMTCkdsb2JhbFNpZ24wHhcNMDkwMzE4MTAwMDAwWhcNMjkwMzE4" +
+        "MTAwMDAwWjBMMSAwHgYDVQQLExdHbG9iYWxTaWduIFJvb3QgQ0EgLSBSMzETMBEG" +
+        "A1UEChMKR2xvYmFsU2lnbjETMBEGA1UEAxMKR2xvYmFsU2lnbjCCASIwDQYJKoZI" +
+        "hvcNAQEBBQADggEPADCCAQoCggEBAMwldpB5BngiFvXAg7aEyiie/QV2EcWtiHL8" +
+        "RgJDx7KKnQRfJMsuS+FggkbhUqsMgUdwbN1k0ev1LKMPgj0MK66X17YUhhB5uzsT" +
+        "gHeMCOFJ0mpiLx9e+pZo34knlTifBtc+ycsmWQ1z3rDI6SYOgxXG71uL0gRgykmm" +
+        "KPZpO/bLyCiR5Z2KYVc3rHQU3HTgOu5yLy6c+9C7v/U9AOEGM+iCK65TpjoWc4zd" +
+        "QQ4gOsC0p6Hpsk+QLjJg6VfLuQSSaGjlOCZgdbKfd/+RFO+uIEn8rUAVSNECMWEZ" +
+        "XriX7613t2Saer9fwRPvm2L7DWzgVGkWqQPabumDk3F2xmmFghcCAwEAAaNCMEAw" +
+        "DgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFI/wS3+o" +
+        "LkUkrk1Q+mOai97i3Ru8MA0GCSqGSIb3DQEBCwUAA4IBAQBLQNvAUKr+yAzv95ZU" +
+        "RUm7lgAJQayzE4aGKAczymvmdLm6AC2upArT9fHxD4q/c2dKg8dEe3jgr25sbwMp" +
+        "jjM5RcOO5LlXbKr8EpbsU8Yt5CRsuZRj+9xTaGdWPoO4zzUhw8lo/s7awlOqzJCK" +
+        "6fBdRoyV3XpYKBovHd7NADdBj+1EbddTKJd+82cEHhXXipa0095MJ6RMG3NzdvQX" +
+        "mcIfeg7jLQitChws/zyrVQ4PkX4268NXSb7hLi18YIvDQVETI53O9zJrlAGomecs" +
+        "Mx86OyXShkDOOyyGeMlhLxS67ttVb9+E7gUJTb0o2HLO02JQZR7rkpeDMdmztcpH" +
+        "WD9f";
 
         protected readonly string _token;
         protected readonly string _tocUrl;
@@ -151,7 +157,29 @@ namespace Fido2NetLib
 
             var rootCert = GetX509Certificate(ROOT_CERT);
             var tocCerts = keyStrings.Select(o => GetX509Certificate(o)).ToArray();
-            var tocPublicKeys = keyStrings.Select(o => GetECDsaPublicKey(o)).ToArray();
+
+            var keys = new List<SecurityKey>();
+
+            foreach (var certString in keyStrings)
+            {
+                var cert = GetX509Certificate(certString);
+
+                var ecdsaPublicKey = cert.GetECDsaPublicKey();
+                if (ecdsaPublicKey != null)
+                {
+                    keys.Add(new ECDsaSecurityKey(ecdsaPublicKey));
+                    continue;
+                }
+
+                var rsaPublicKey = cert.GetRSAPublicKey();
+                if (rsaPublicKey != null)
+                {
+                    keys.Add(new RsaSecurityKey(rsaPublicKey));
+                    continue;
+                }
+                throw new Fido2MetadataException("Unknown certificate algorithm");
+            }
+            var tocPublicKeys = keys.ToArray();
 
             var certChain = new X509Chain();
             certChain.ChainPolicy.ExtraStore.Add(rootCert);


### PR DESCRIPTION
The FIDO Alliance have recently changed the root certificate for their Metadata Service table of contents (TOC).  The certificates in the TOC certificate chain have also changed from being ECC to RSA.  This branch contains the new TOC root certificate and support for RSA in addition to ECC keys in the intermediate and signing certificates within the X5c data.