### PR TITLE
Changed the AttstationType for Windows Hello Authenticator back to Full

### DIFF
--- a/Src/Fido2/Metadata/StaticMetadataRepository.cs
+++ b/Src/Fido2/Metadata/StaticMetadataRepository.cs
@@ -214,7 +214,7 @@ namespace Fido2NetLib
                 {
                     AttestationTypes = new ushort[]
                     {
-                        15888
+                        (ushort)MetadataAttestationType.ATTESTATION_BASIC_FULL
                     },
                     Hash = "",
                     Description = "Windows Hello Hardware Authenticator",


### PR DESCRIPTION
With the current AttestationType Value of 1588 it's not possible to register a new Windows Hello Authenticator when requesting 'direct' oder 'indirect' because the certificate is not self-signed. The AuthenticatorAttestationResponse fails with an Exception 'Attestation with full attestation from authenticator that does not support full attestation'. #226 
Using ATTESTATION_BASIC_FULL instead of 1588 fixes the problem.

The value was changed in a previous [commit](https://github.com/abergs/fido2-net-lib/commit/1c80ae0c951cec008324a523500e74d311f9b05a#diff-de3ccd7abcceb7fe8312f269b73f75853baf4c5de3b8b66235f5418c4af1d31b), guess there was a reason for that change, maybe you can check if my change breaks something.